### PR TITLE
Fix build for everybody

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,22 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
+// This file exists in root folder and it is a dummy file.
+// When releasing, replace it by the real key
 def keystorePropertiesFile = rootProject.file("keystore.properties")
+
 def keystoreProperties = new Properties()
 keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 
 android {
     signingConfigs {
         config {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
+            if (keystorePropertiesFile.exists()) {
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+            }
         }
     }
     buildToolsVersion '26.0.2'
@@ -24,19 +29,13 @@ android {
         versionName "1.0.8"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
-    testBuildType "dev"
+    testBuildType "debug"
     buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-
-        dev {
-            signingConfig signingConfigs.debug
+        debug {
             buildConfigField 'String', "BASE_URL", '"https://10.0.2.2:3000"'
         }
 
-        prod {
+        release {
             signingConfig signingConfigs.config
             shrinkResources true
             minifyEnabled true

--- a/keystore.properties
+++ b/keystore.properties
@@ -1,0 +1,7 @@
+// fake keystore.properties
+
+storePassword=
+keyPassword=
+keyAlias=
+// storeFile cannot be null
+storeFile=.


### PR DESCRIPTION
- Added a dummy property file to it. In the future, we can remove it all but the sign in must be done manually.
- Removed prod build config. Just removed because I did not know what it was about.
- Now, everybody can download the project and run. No more configs are needed.
- When you gonna sign, just replace the dummy config to the original and everything will work (need the jks tools either)
