### PR TITLE
Waiting adapter to be ready for start scanning.

### DIFF
--- a/app/src/main/java/org/falaeapp/falae/adapter/ItemPagerAdapter.kt
+++ b/app/src/main/java/org/falaeapp/falae/adapter/ItemPagerAdapter.kt
@@ -3,25 +3,39 @@ package org.falaeapp.falae.adapter
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
 import android.support.v4.app.FragmentStatePagerAdapter
+import android.util.SparseArray
+import android.view.ViewGroup
 import org.falaeapp.falae.fragment.ViewPagerItemFragment
 import org.falaeapp.falae.model.Page
+import java.lang.ref.WeakReference
 import java.util.*
 import kotlin.math.min
 import kotlin.math.roundToInt
 
+
 class ItemPagerAdapter(fm: FragmentManager, private val page: Page, private val marginWidth: Int) : FragmentStatePagerAdapter(fm) {
     private val pageCount: Int
+    private val fragmentReferences = SparseArray<WeakReference<Fragment>>()
 
     init {
         pageCount = calculatePageCount()
     }
 
     override fun getItem(position: Int): Fragment {
-        val items = page.items
-        val itemsPerPage = page.columns * page.rows
-        val fromIndex = position * itemsPerPage
-        val subList = items.subList(fromIndex, min(fromIndex + itemsPerPage, items.size))
-        return ViewPagerItemFragment.newInstance(ArrayList(subList), page.columns, page.rows, marginWidth)
+        return fragmentReferences.get(position)?.get() ?: run {
+            val items = page.items
+            val itemsPerPage = page.columns * page.rows
+            val fromIndex = position * itemsPerPage
+            val subList = items.subList(fromIndex, min(fromIndex + itemsPerPage, items.size))
+            val newInstance: Fragment = ViewPagerItemFragment.newInstance(ArrayList(subList), page.columns, page.rows, marginWidth)
+            fragmentReferences.put(position, WeakReference(newInstance))
+            newInstance
+        }
+    }
+
+    override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
+        fragmentReferences.remove(position)
+        super.destroyItem(container, position, `object`)
     }
 
     override fun getCount(): Int = pageCount

--- a/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
@@ -28,6 +28,7 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
     private lateinit var leftNavHolder: FrameLayout
     private lateinit var rightNavHolder: FrameLayout
     private lateinit var displayViewModel: DisplayViewModel
+    private var itemCurrentPosition = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -74,22 +75,9 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
                 mPager.addOnPageChangeListener(object : ViewPager.SimpleOnPageChangeListener() {
                     override fun onPageSelected(position: Int) {
                         handleNavButtons()
+                        handleFragmentLifeCycle(position)
                     }
                 })
-                mPager.addOnPageChangeListener(object : ViewPager.SimpleOnPageChangeListener() {
-                    var currentPosition = 0
-
-                    override fun onPageSelected(newPosition: Int) {
-                        val fragmentToShow = mPagerAdapter.getItem(newPosition) as FragmentLifecycle
-                        fragmentToShow.onResumeFragment()
-
-                        val fragmentToHide = mPagerAdapter.getItem(currentPosition) as FragmentLifecycle
-                        fragmentToHide.onPauseFragment()
-
-                        currentPosition = newPosition
-                    }
-                })
-
                 if (shouldEnableNavButtons()) {
                     handleNavButtons()
                 }
@@ -127,6 +115,18 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
                 mPager.currentItem = ++currentItem
             }
         }
+    }
+
+    private fun handleFragmentLifeCycle(position: Int) {
+        val fragmentToShow = mPagerAdapter.getItem(position)
+        fragmentToShow.userVisibleHint = true
+        (fragmentToShow as FragmentLifecycle).onResumeFragment()
+
+        val fragmentToHide = mPagerAdapter.getItem(itemCurrentPosition)
+        userVisibleHint = false
+        (fragmentToHide as FragmentLifecycle).onPauseFragment()
+
+        itemCurrentPosition = position
     }
 
     private fun handleNavButtons() {

--- a/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
@@ -76,6 +76,19 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
                         handleNavButtons()
                     }
                 })
+                mPager.addOnPageChangeListener(object : ViewPager.SimpleOnPageChangeListener() {
+                    var currentPosition = 0
+
+                    override fun onPageSelected(newPosition: Int) {
+                        val fragmentToShow = mPagerAdapter.getItem(newPosition) as FragmentLifecycle
+                        fragmentToShow.onResumeFragment()
+
+                        val fragmentToHide = mPagerAdapter.getItem(currentPosition) as FragmentLifecycle
+                        fragmentToHide.onPauseFragment()
+
+                        currentPosition = newPosition
+                    }
+                })
 
                 if (shouldEnableNavButtons()) {
                     handleNavButtons()
@@ -170,4 +183,12 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
             return PageFragment()
         }
     }
+
+}
+
+interface FragmentLifecycle {
+
+    fun onPauseFragment()
+    fun onResumeFragment()
+
 }

--- a/app/src/main/java/org/falaeapp/falae/fragment/ViewPagerItemFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/ViewPagerItemFragment.kt
@@ -59,14 +59,6 @@ class ViewPagerItemFragment : Fragment(), FragmentLifecycle {
         } ?: return
     }
 
-    override fun onResumeFragment() {
-        doPageScan()
-    }
-
-    override fun onPauseFragment() {
-        stopPageScan()
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.fragment_view_pager_item, container, false)
@@ -109,6 +101,14 @@ class ViewPagerItemFragment : Fragment(), FragmentLifecycle {
 
     override fun onPause() {
         super.onPause()
+        stopPageScan()
+    }
+
+    override fun onResumeFragment() {
+        doPageScan()
+    }
+
+    override fun onPauseFragment() {
         stopPageScan()
     }
 
@@ -214,17 +214,6 @@ class ViewPagerItemFragment : Fragment(), FragmentLifecycle {
         drawable.setColor(item.category.color())
         return drawable
     }
-
-    private fun getResizedDrawable(drawableId: Int, size: Int): Drawable {
-        val drawable: Drawable? = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            context?.resources?.getDrawable(drawableId)
-        } else {
-            context?.getDrawable(drawableId)
-        }
-        val bitmap = (drawable as BitmapDrawable).bitmap
-        return BitmapDrawable(resources, Bitmap.createScaledBitmap(bitmap, size, size, true))
-    }
-
 
     private fun doPageScan() {
         currentItemSelectedFromScan = -1


### PR DESCRIPTION
The previous PR has a bug that when page changes to another the scan mode doesn't wait for the fragment to be ready to start the scan. So scan mode was considering the size of the items of the previous page causing the first item of the next page to not highlight.
This PR is to wait for the Pager to be ready so the scan mode can start. Also it fixes some small issues about re-use the same Timer class since we are not creating new fragments for when the user changes de page. We are storing the reference of the created fragment so when the page changes, we just retrieve that same fragment again.