### PR TITLE
Migrate to AndroidX

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,14 +25,14 @@ android {
         }
     }
     buildToolsVersion '28.0.3'
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "org.falaeapp.falae"
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 18
         versionName "1.0.18"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     testBuildType "debug"
     buildTypes {
@@ -58,31 +58,32 @@ androidExtensions {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'commons-io:commons-io:20030203.000550'
-    implementation 'com.android.support:design:' + rootProject.supportLibVersion
+    implementation "com.android.support:design:$rootProject.supportLibVersion"
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'com.android.volley:volley:1.1.0'
-    implementation 'com.android.support.constraint:constraint-layout:2.0.0-beta2'
-    implementation 'com.android.support:gridlayout-v7:' + rootProject.supportLibVersion
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation "com.android.support:gridlayout-v7:$rootProject.supportLibVersion"
     implementation 'jp.wasabeef:picasso-transformations:2.1.2'
-    implementation 'com.google.android.gms:play-services-base:16.1.0'
-    implementation 'com.android.support:appcompat-v7:' + rootProject.supportLibVersion
-    implementation 'com.android.support:recyclerview-v7:' + rootProject.supportLibVersion
-    implementation 'com.android.support:support-v4:' + rootProject.supportLibVersion
-    implementation "android.arch.lifecycle:extensions:$rootProject.archLifecycleVersion"
-    implementation "android.arch.persistence.room:runtime:$rootProject.archRoomVersion"
-    kapt "android.arch.lifecycle:compiler:$rootProject.archLifecycleVersion"
-    kapt "android.arch.persistence.room:compiler:$rootProject.archRoomVersion"
-    implementation "org.jetbrains.anko:anko-appcompat-v7-commons:$anko_version"
+    implementation 'com.google.android.gms:play-services-base:17.1.0'
+    implementation "com.android.support:appcompat-v7:$rootProject.supportLibVersion"
+    implementation "com.android.support:recyclerview-v7:$rootProject.supportLibVersion"
+    implementation "com.android.support:support-v4:$rootProject.supportLibVersion"
+    implementation "androidx.lifecycle:lifecycle-extensions:2.2.0-alpha05"
+    implementation "androidx.room:room-runtime:2.2.0-rc01"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0-alpha05'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0-alpha05'
+    kapt "androidx.lifecycle:lifecycle-compiler:$rootProject.archLifecycleVersion"
+    kapt "androidx.room:room-compiler:$rootProject.archRoomVersion"
     testImplementation 'junit:junit:4.13-beta-3'
     testImplementation 'org.hamcrest:hamcrest-library:2.1'
     testImplementation 'junit:junit:4.13-beta-3'
     testImplementation 'org.mockito:mockito-core:2.27.0'
-    testImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0'
+    testImplementation 'androidx.test.espresso:espresso-core:3.3.0-alpha02'
 }
 repositories {
     mavenCentral()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,14 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
+    compileOptions {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+    }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
     def RELEASE_PROPERTIES = "keys/release_keystore.properties"
 
     signingConfigs {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,6 +81,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.27.0'
     testImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0'
 }
 repositories {
     mavenCentral()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,10 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
+apply plugin: 'org.jetbrains.kotlin.android.extensions'
+androidExtensions {
+    experimental = true
+}
 
 android {
     compileOptions {
@@ -57,35 +62,30 @@ android {
         }
     }
 }
-apply plugin: 'org.jetbrains.kotlin.android.extensions'
-apply plugin: 'kotlin-kapt'
-androidExtensions {
-    experimental = true
-}
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'commons-io:commons-io:20030203.000550'
-    implementation "com.android.support:design:$rootProject.supportLibVersion"
+    implementation "com.android.support:design:29.0.0"
+    implementation "com.android.support:appcompat-v7:29.0.0"
+    implementation "com.android.support:recyclerview-v7:29.0.0"
+    implementation "com.android.support:support-v4:29.0.0"
+    implementation "com.android.support:gridlayout-v7:29.0.0"
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'com.android.volley:volley:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation "com.android.support:gridlayout-v7:$rootProject.supportLibVersion"
     implementation 'jp.wasabeef:picasso-transformations:2.1.2'
     implementation 'com.google.android.gms:play-services-base:17.1.0'
-    implementation "com.android.support:appcompat-v7:$rootProject.supportLibVersion"
-    implementation "com.android.support:recyclerview-v7:$rootProject.supportLibVersion"
-    implementation "com.android.support:support-v4:$rootProject.supportLibVersion"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0-alpha05"
     implementation "androidx.room:room-runtime:2.2.0-rc01"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0-alpha05'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0-alpha05'
-    kapt "androidx.lifecycle:lifecycle-compiler:$rootProject.archLifecycleVersion"
-    kapt "androidx.room:room-compiler:$rootProject.archRoomVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0-alpha05"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.2.0-alpha05"
+    kapt "androidx.lifecycle:lifecycle-compiler:2.2.0-alpha05"
+    kapt "androidx.room:room-compiler:2.2.0-rc01"
     testImplementation 'junit:junit:4.13-beta-3'
     testImplementation 'org.hamcrest:hamcrest-library:2.1'
     testImplementation 'junit:junit:4.13-beta-3'

--- a/app/src/androidTest/java/org/falaeapp/falae/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/org/falaeapp/falae/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package org.falaeapp.falae;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/app/src/main/java/org/falaeapp/falae/Event.kt
+++ b/app/src/main/java/org/falaeapp/falae/Event.kt
@@ -12,7 +12,7 @@ open class Event<out T>(private val content: T) {
      * Returns the content and prevents its use again.
      */
     fun getContentIfNotHandled(): T? {
-        return if (hasBeenHandled) {
+        return if (hasBeenHandled || content is Unit) {
             null
         } else {
             hasBeenHandled = true

--- a/app/src/main/java/org/falaeapp/falae/Event.kt
+++ b/app/src/main/java/org/falaeapp/falae/Event.kt
@@ -5,18 +5,28 @@ package org.falaeapp.falae
  */
 open class Event<out T>(private val content: T) {
 
-    var hasBeenHandled = false
-        private set // Allow external read but not write
+    private var hasBeenHandled = false
 
     /**
      * Returns the content and prevents its use again.
      */
     fun getContentIfNotHandled(): T? {
-        return if (hasBeenHandled || content is Unit) {
+        return if (hasBeenHandled) {
             null
         } else {
             hasBeenHandled = true
             content
+        }
+    }
+
+    /**
+     * Returns the content if the event is not Unit type.
+     */
+    fun getContentIfNotEmpty(): T? {
+        return if (content is Unit) {
+            null
+        } else {
+            getContentIfNotHandled()
         }
     }
 

--- a/app/src/main/java/org/falaeapp/falae/Event.kt
+++ b/app/src/main/java/org/falaeapp/falae/Event.kt
@@ -22,7 +22,7 @@ open class Event<out T>(private val content: T) {
     /**
      * Returns the content if the event is not Unit type.
      */
-    fun getContentIfNotEmpty(): T? {
+    fun getContentIfAny(): T? {
         return if (content is Unit) {
             null
         } else {

--- a/app/src/main/java/org/falaeapp/falae/Extension.kt
+++ b/app/src/main/java/org/falaeapp/falae/Extension.kt
@@ -1,7 +1,7 @@
 package org.falaeapp.falae
 
 import android.content.res.Resources
-import android.support.v7.app.AlertDialog
+import androidx.appcompat.app.AlertDialog
 import com.google.gson.Gson
 import org.falaeapp.falae.model.User
 import java.io.File

--- a/app/src/main/java/org/falaeapp/falae/Extension.kt
+++ b/app/src/main/java/org/falaeapp/falae/Extension.kt
@@ -1,6 +1,7 @@
 package org.falaeapp.falae
 
 import android.content.res.Resources
+import android.support.v7.app.AlertDialog
 import com.google.gson.Gson
 import org.falaeapp.falae.model.User
 import java.io.File
@@ -22,3 +23,12 @@ fun Resources.loadUser(name: String): User {
 
 fun InputStream.readText(charset: Charset = Charsets.UTF_8): String =
         bufferedReader(charset).use { it.readText() }
+
+fun AlertDialog.loadDefaultShowListener(resources: Resources) {
+    setOnShowListener {
+        val buttonPositive = getButton(AlertDialog.BUTTON_POSITIVE)
+        val buttonNegative = getButton(AlertDialog.BUTTON_NEGATIVE)
+        buttonPositive.setTextColor(resources.getColor(R.color.colorAccent))
+        buttonNegative.setTextColor(resources.getColor(R.color.colorAccent))
+    }
+}

--- a/app/src/main/java/org/falaeapp/falae/activity/DisplayActivity.kt
+++ b/app/src/main/java/org/falaeapp/falae/activity/DisplayActivity.kt
@@ -26,9 +26,11 @@ class DisplayActivity : AppCompatActivity(), PageFragment.PageFragmentListener,
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_display)
 
-        val spreadSheet: SpreadSheet = intent.getParcelableExtra(SPREADSHEET)
+        val spreadSheet: SpreadSheet? = intent.getParcelableExtra(SPREADSHEET)
         displayViewModel = ViewModelProvider(this).get(DisplayViewModel::class.java)
-        displayViewModel.init(spreadSheet)
+        spreadSheet?.let {
+            displayViewModel.init(it)
+        }
 
         displayViewModel.pageToOpen.observe(this, Observer {
             it?.let { page ->

--- a/app/src/main/java/org/falaeapp/falae/activity/DisplayActivity.kt
+++ b/app/src/main/java/org/falaeapp/falae/activity/DisplayActivity.kt
@@ -1,14 +1,14 @@
 package org.falaeapp.falae.activity
 
-import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.media.MediaPlayer
 import android.os.Build
 import android.os.Bundle
-import android.support.v4.app.FragmentManager
-import android.support.v7.app.AppCompatActivity
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import org.falaeapp.falae.R
 import org.falaeapp.falae.fragment.PageFragment
 import org.falaeapp.falae.fragment.ViewPagerItemFragment
@@ -17,7 +17,8 @@ import org.falaeapp.falae.model.SpreadSheet
 import org.falaeapp.falae.service.TextToSpeechService
 import org.falaeapp.falae.viewmodel.DisplayViewModel
 
-class DisplayActivity : AppCompatActivity(), PageFragment.PageFragmentListener, ViewPagerItemFragment.ViewPagerItemFragmentListener {
+class DisplayActivity : AppCompatActivity(), PageFragment.PageFragmentListener,
+    ViewPagerItemFragment.ViewPagerItemFragmentListener {
     private lateinit var displayViewModel: DisplayViewModel
     private lateinit var mediaPlayer: MediaPlayer
 
@@ -26,7 +27,7 @@ class DisplayActivity : AppCompatActivity(), PageFragment.PageFragmentListener, 
         setContentView(R.layout.activity_display)
 
         val spreadSheet: SpreadSheet = intent.getParcelableExtra(SPREADSHEET)
-        displayViewModel = ViewModelProviders.of(this).get(DisplayViewModel::class.java)
+        displayViewModel = ViewModelProvider(this).get(DisplayViewModel::class.java)
         displayViewModel.init(spreadSheet)
 
         displayViewModel.pageToOpen.observe(this, Observer {
@@ -43,10 +44,12 @@ class DisplayActivity : AppCompatActivity(), PageFragment.PageFragmentListener, 
         val fragment = PageFragment.newInstance()
         val fragmentManager = supportFragmentManager
         val fragmentTransaction = fragmentManager
-                .beginTransaction()
-                .setCustomAnimations(android.R.anim.fade_in, android.R.anim.fade_out,
-                        android.R.anim.fade_in, android.R.anim.fade_out)
-                .replace(R.id.page_container, fragment)
+            .beginTransaction()
+            .setCustomAnimations(
+                android.R.anim.fade_in, android.R.anim.fade_out,
+                android.R.anim.fade_in, android.R.anim.fade_out
+            )
+            .replace(R.id.page_container, fragment)
         if (addToBackStack) {
             fragmentTransaction.addToBackStack(page.name)
         } else if (fragmentManager.backStackEntryCount > 0) {

--- a/app/src/main/java/org/falaeapp/falae/activity/MainActivity.kt
+++ b/app/src/main/java/org/falaeapp/falae/activity/MainActivity.kt
@@ -114,8 +114,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         title = item.title
         mDrawer.closeDrawer(GravityCompat.START)
 
-        val id = item.itemId
-        when (id) {
+        when (val id = item.itemId) {
             R.id.add_user -> {
                 fragment = SyncUserFragment.newInstance()
                 tag = SyncUserFragment::class.java.simpleName

--- a/app/src/main/java/org/falaeapp/falae/activity/MainActivity.kt
+++ b/app/src/main/java/org/falaeapp/falae/activity/MainActivity.kt
@@ -63,6 +63,23 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         userViewModel = ViewModelProvider(this).get(UserViewModel::class.java)
 
         userViewModel.handleNewVersion(BuildConfig.VERSION_CODE)
+        observeUsers()
+        observeLastConnectedUser()
+
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+            ProviderInstaller.installIfNeededAsync(this, this)
+        }
+    }
+
+    private fun observeLastConnectedUser() {
+        userViewModel.lastConnectedUserId.observe(this, Observer {
+            it?.let { lastConnectedUserId ->
+                openUserItem(lastConnectedUserId)
+            }
+        })
+    }
+
+    private fun observeUsers() {
         userViewModel.users.observe(this, Observer<List<User>> { users ->
             mNavigationView.menu.removeGroup(R.id.users_group)
             users?.reversed()?.forEach {
@@ -70,15 +87,6 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
             }
             userViewModel.loadLastConnectedUser()
         })
-        userViewModel.lastConnectedUserId.observe(this, Observer {
-            it?.let { lastConnectedUserId ->
-                openUserItem(lastConnectedUserId)
-            }
-        })
-
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-            ProviderInstaller.installIfNeededAsync(this, this)
-        }
     }
 
     private fun openUserItem(userId: Long) {

--- a/app/src/main/java/org/falaeapp/falae/activity/MainActivity.kt
+++ b/app/src/main/java/org/falaeapp/falae/activity/MainActivity.kt
@@ -1,27 +1,27 @@
 package org.falaeapp.falae.activity
 
 import android.app.Activity
-import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.speech.tts.TextToSpeech
-import android.support.design.widget.NavigationView
-import android.support.v4.app.Fragment
-import android.support.v4.view.GravityCompat
-import android.support.v4.widget.DrawerLayout
-import android.support.v7.app.ActionBarDrawerToggle
-import android.support.v7.app.AppCompatActivity
-import android.support.v7.widget.Toolbar
 import android.util.Log
 import android.view.MenuItem
 import android.view.Window
 import android.view.WindowManager
 import android.widget.Toast
+import androidx.appcompat.app.ActionBarDrawerToggle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.core.view.GravityCompat
+import androidx.drawerlayout.widget.DrawerLayout
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.security.ProviderInstaller
+import com.google.android.material.navigation.NavigationView
 import org.falaeapp.falae.BuildConfig
 import org.falaeapp.falae.R
 import org.falaeapp.falae.fragment.SettingsFragment
@@ -32,9 +32,9 @@ import org.falaeapp.falae.model.User
 import org.falaeapp.falae.viewmodel.UserViewModel
 
 class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener,
-        TabPagerFragment.TabPagerFragmentListener,
-        SyncUserFragment.SyncUserFragmentListener,
-        ProviderInstaller.ProviderInstallListener {
+    TabPagerFragment.TabPagerFragmentListener,
+    SyncUserFragment.SyncUserFragmentListener,
+    ProviderInstaller.ProviderInstallListener {
 
     private lateinit var mDrawer: DrawerLayout
     private lateinit var mNavigationView: NavigationView
@@ -52,14 +52,16 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
         mDrawer = findViewById(R.id.drawer_layout)
         val toggle = ActionBarDrawerToggle(
-                this, mDrawer, toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close)
+            this, mDrawer, toolbar, R.string.navigation_drawer_open, R.string.navigation_drawer_close
+        )
         mDrawer.addDrawerListener(toggle)
         toggle.syncState()
         mDrawer.openDrawer(GravityCompat.START)
         mNavigationView = findViewById(R.id.nav_view)
         mNavigationView.setNavigationItemSelectedListener(this)
 
-        userViewModel = ViewModelProviders.of(this).get(UserViewModel::class.java)
+        userViewModel = ViewModelProvider(this).get(UserViewModel::class.java)
+
         userViewModel.handleNewVersion(BuildConfig.VERSION_CODE)
         userViewModel.users.observe(this, Observer<List<User>> { users ->
             mNavigationView.menu.removeGroup(R.id.users_group)
@@ -139,10 +141,12 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
     private fun changeFragment(fragment: Fragment, tag: String) {
         supportFragmentManager.beginTransaction()
-                .setCustomAnimations(R.anim.enter_from_right, R.anim.exit_to_left,
-                        R.anim.enter_from_left, R.anim.exit_to_right)
-                .replace(R.id.container, fragment, tag)
-                .commit()
+            .setCustomAnimations(
+                R.anim.enter_from_right, R.anim.exit_to_left,
+                R.anim.enter_from_left, R.anim.exit_to_right
+            )
+            .replace(R.id.container, fragment, tag)
+            .commit()
     }
 
     private fun openTTSLanguageSettings() {
@@ -165,9 +169,9 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     override fun onProviderInstallFailed(errorCode: Int, recoveryIntent: Intent?) {
         if (GoogleApiAvailability.getInstance().isUserResolvableError(errorCode)) {
             GoogleApiAvailability.getInstance().showErrorDialogFragment(
-                    this,
-                    errorCode,
-                    ERROR_DIALOG_REQUEST_CODE
+                this,
+                errorCode,
+                ERROR_DIALOG_REQUEST_CODE
             ) {
                 onProviderInstallerNotAvailable()
             }
@@ -176,8 +180,10 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         }
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int,
-                                  data: Intent?) {
+    override fun onActivityResult(
+        requestCode: Int, resultCode: Int,
+        data: Intent?
+    ) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == ERROR_DIALOG_REQUEST_CODE) {
             if (resultCode == Activity.RESULT_CANCELED)

--- a/app/src/main/java/org/falaeapp/falae/activity/SplashActivity.kt
+++ b/app/src/main/java/org/falaeapp/falae/activity/SplashActivity.kt
@@ -2,7 +2,7 @@ package org.falaeapp.falae.activity
 
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 
 class SplashActivity : AppCompatActivity() {
 

--- a/app/src/main/java/org/falaeapp/falae/adapter/ItemPagerAdapter.kt
+++ b/app/src/main/java/org/falaeapp/falae/adapter/ItemPagerAdapter.kt
@@ -1,19 +1,19 @@
 package org.falaeapp.falae.adapter
 
+import android.util.SparseArray
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
-import android.util.SparseArray
-import android.view.ViewGroup
 import org.falaeapp.falae.fragment.ViewPagerItemFragment
 import org.falaeapp.falae.model.Page
 import java.lang.ref.WeakReference
-import java.util.*
+import java.util.ArrayList
 import kotlin.math.min
 import kotlin.math.roundToInt
 
-
-class ItemPagerAdapter(fm: FragmentManager, private val page: Page, private val marginWidth: Int) : FragmentStatePagerAdapter(fm) {
+class ItemPagerAdapter(fm: FragmentManager, private val page: Page, private val marginWidth: Int) :
+    FragmentStatePagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
     private val pageCount: Int
     private val fragmentReferences = SparseArray<WeakReference<Fragment>>()
 
@@ -27,7 +27,8 @@ class ItemPagerAdapter(fm: FragmentManager, private val page: Page, private val 
             val itemsPerPage = page.columns * page.rows
             val fromIndex = position * itemsPerPage
             val subList = items.subList(fromIndex, min(fromIndex + itemsPerPage, items.size))
-            val newInstance: Fragment = ViewPagerItemFragment.newInstance(ArrayList(subList), page.columns, page.rows, marginWidth)
+            val newInstance: Fragment =
+                ViewPagerItemFragment.newInstance(ArrayList(subList), page.columns, page.rows, marginWidth)
             fragmentReferences.put(position, WeakReference(newInstance))
             newInstance
         }

--- a/app/src/main/java/org/falaeapp/falae/adapter/ItemPagerAdapter.kt
+++ b/app/src/main/java/org/falaeapp/falae/adapter/ItemPagerAdapter.kt
@@ -1,8 +1,8 @@
 package org.falaeapp.falae.adapter
 
-import android.support.v4.app.Fragment
-import android.support.v4.app.FragmentManager
-import android.support.v4.app.FragmentStatePagerAdapter
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentStatePagerAdapter
 import android.util.SparseArray
 import android.view.ViewGroup
 import org.falaeapp.falae.fragment.ViewPagerItemFragment

--- a/app/src/main/java/org/falaeapp/falae/adapter/SpreadSheetAdapter.kt
+++ b/app/src/main/java/org/falaeapp/falae/adapter/SpreadSheetAdapter.kt
@@ -1,7 +1,7 @@
 package org.falaeapp.falae.adapter
 
 import android.content.Context
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/org/falaeapp/falae/exception/NoNetworkConnectionException.kt
+++ b/app/src/main/java/org/falaeapp/falae/exception/NoNetworkConnectionException.kt
@@ -1,0 +1,5 @@
+package org.falaeapp.falae.exception
+
+import java.io.IOException
+
+class NoNetworkConnectionException(msg: String) : IOException(msg)

--- a/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
@@ -19,7 +19,6 @@ import org.falaeapp.falae.viewmodel.DisplayViewModel
 
 class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
 
-
     private lateinit var mPageFragmentListener: PageFragmentListener
     private lateinit var mPager: ViewPager
     private lateinit var mPagerAdapter: ItemPagerAdapter
@@ -28,15 +27,16 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
     private lateinit var leftNavHolder: FrameLayout
     private lateinit var rightNavHolder: FrameLayout
     private lateinit var displayViewModel: DisplayViewModel
-    private var itemCurrentPosition = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         displayViewModel = ViewModelProvider(activity!!).get(DisplayViewModel::class.java)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
-                              savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         val view = inflater.inflate(R.layout.fragment_page, container, false)
         leftNav = view.findViewById(R.id.left_nav) as ImageView
         rightNav = view.findViewById(R.id.right_nav) as ImageView
@@ -75,7 +75,6 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
                 mPager.addOnPageChangeListener(object : ViewPager.SimpleOnPageChangeListener() {
                     override fun onPageSelected(position: Int) {
                         handleNavButtons()
-                        handleFragmentLifeCycle(position)
                     }
                 })
                 if (shouldEnableNavButtons()) {
@@ -94,7 +93,8 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
                 rightNavHolder.setOnClickListener {
                     var tab = mPager.currentItem
                     if (isPagerAdapterInitialized() &&
-                            mPagerAdapter.count > 1 && tab != mPagerAdapter.count - 1) {
+                        mPagerAdapter.count > 1 && tab != mPagerAdapter.count - 1
+                    ) {
                         speak(getString(R.string.next))
                     }
                     tab++
@@ -117,20 +117,6 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
         }
     }
 
-    private fun handleFragmentLifeCycle(position: Int) {
-        val fragmentToShow = mPagerAdapter.getItem(position)
-        // When user changes the page by sliding the screen, userVisibleHint doesn't change.
-        // So we manually set the userVisibleHint
-        fragmentToShow.userVisibleHint = true
-        (fragmentToShow as FragmentLifecycle).onResumeFragment()
-
-        val fragmentToHide = mPagerAdapter.getItem(itemCurrentPosition)
-        fragmentToHide.userVisibleHint = false
-        (fragmentToHide as FragmentLifecycle).onPauseFragment()
-
-        itemCurrentPosition = position
-    }
-
     private fun handleNavButtons() {
         enableNavButtons()
         if (shouldDisableLeftNavButton()) {
@@ -149,13 +135,13 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
     private fun isPagerAdapterInitialized(): Boolean = this::mPagerAdapter.isInitialized
 
     private fun shouldEnableNavButtons(): Boolean = isPagerAdapterInitialized() &&
-            mPagerAdapter.count > 1
+        mPagerAdapter.count > 1
 
     private fun shouldDisableLeftNavButton(): Boolean = isPagerAdapterInitialized() &&
-            mPager.currentItem == 0
+        mPager.currentItem == 0
 
     private fun shouldDisableRightButton(): Boolean = isPagerAdapterInitialized() &&
-            mPager.currentItem >= mPagerAdapter.count - 1
+        mPager.currentItem >= mPagerAdapter.count - 1
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -185,10 +171,4 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
             return PageFragment()
         }
     }
-
-}
-
-interface FragmentLifecycle {
-    fun onPauseFragment()
-    fun onResumeFragment()
 }

--- a/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
@@ -60,7 +60,7 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
                 leftNavHolder.layoutParams.width = navHoldersSize
                 rightNavHolder.layoutParams.width = navHoldersSize
                 if (isPagerAdapterInitialized().not()) {
-                    displayViewModel.currentPage.observe(this@PageFragment, Observer {
+                    displayViewModel.currentPage.observe(viewLifecycleOwner, Observer {
                         it?.let { page ->
                             mPagerAdapter = ItemPagerAdapter(childFragmentManager, page, navHoldersSize * 2)
                         }

--- a/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
@@ -1,18 +1,18 @@
 package org.falaeapp.falae.fragment
 
-import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.os.Build
 import android.os.Bundle
-import android.support.v4.app.Fragment
-import android.support.v4.view.ViewPager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.widget.FrameLayout
 import android.widget.ImageView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.viewpager.widget.ViewPager
 import org.falaeapp.falae.R
 import org.falaeapp.falae.adapter.ItemPagerAdapter
 import org.falaeapp.falae.viewmodel.DisplayViewModel
@@ -32,7 +32,7 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        displayViewModel = ViewModelProviders.of(activity!!).get(DisplayViewModel::class.java)
+        displayViewModel = ViewModelProvider(activity!!).get(DisplayViewModel::class.java)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
@@ -52,7 +52,7 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
                     view.viewTreeObserver.removeOnGlobalLayoutListener(this)
                 }
                 mPager = view.findViewById(R.id.pager) as ViewPager
-                val navHoldersSize = java.lang.Double.valueOf(mPager.measuredWidth * 0.065)!!.toInt()
+                val navHoldersSize = java.lang.Double.valueOf(mPager.measuredWidth * 0.065).toInt()
                 leftNav.layoutParams.width = navHoldersSize
                 leftNav.layoutParams.height = navHoldersSize
                 rightNav.layoutParams.width = navHoldersSize
@@ -157,12 +157,12 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
     private fun shouldDisableRightButton(): Boolean = isPagerAdapterInitialized() &&
             mPager.currentItem >= mPagerAdapter.count - 1
 
-    override fun onAttach(context: Context?) {
+    override fun onAttach(context: Context) {
         super.onAttach(context)
         if (context is PageFragmentListener) {
             mPageFragmentListener = context
         } else {
-            throw RuntimeException(context!!.toString() + " must implement PageFragmentListener")
+            throw RuntimeException("$context must implement PageFragmentListener")
         }
     }
 

--- a/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
@@ -60,10 +60,8 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
                 leftNavHolder.layoutParams.width = navHoldersSize
                 rightNavHolder.layoutParams.width = navHoldersSize
                 if (isPagerAdapterInitialized().not()) {
-                    displayViewModel.currentPage.observe(viewLifecycleOwner, Observer {
-                        it?.let { page ->
-                            mPagerAdapter = ItemPagerAdapter(childFragmentManager, page, navHoldersSize * 2)
-                        }
+                    displayViewModel.currentPage.observe(viewLifecycleOwner, Observer { page ->
+                        mPagerAdapter = ItemPagerAdapter(childFragmentManager, page, navHoldersSize * 2)
                     })
                 }
                 if (::mPager.isInitialized && isPagerAdapterInitialized()) {

--- a/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/PageFragment.kt
@@ -125,7 +125,7 @@ class PageFragment : Fragment(), ViewPagerItemFragment.PageInteractionListener {
         (fragmentToShow as FragmentLifecycle).onResumeFragment()
 
         val fragmentToHide = mPagerAdapter.getItem(itemCurrentPosition)
-        userVisibleHint = false
+        fragmentToHide.userVisibleHint = false
         (fragmentToHide as FragmentLifecycle).onPauseFragment()
 
         itemCurrentPosition = position

--- a/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
@@ -51,24 +51,22 @@ class SettingsFragment : Fragment() {
                 isChecked
             )
         }
-        settingsViewModel.setSeekBarProgress(0)
 
-        seekBar.setOnSeekBarChangeListener(
-            object : SeekBar.OnSeekBarChangeListener {
-                override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
-                    val actualProgress = progress + 1
-                    setSeekBarText(actualProgress)
-                    settingsViewModel.setSeekBarProgress(actualProgress)
-                    val timeMillis: Long = (actualProgress * 500).toLong()
-                    settingsViewModel.setScanModeDuration(timeMillis)
-                }
+        seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+                val actualProgress = progress + 1
+                setSeekBarText(actualProgress)
+                settingsViewModel.setSeekBarProgress(actualProgress)
+                val timeMillis: Long = (actualProgress * 500).toLong()
+                settingsViewModel.setScanModeDuration(timeMillis)
+            }
 
-                override fun onStartTrackingTouch(seekBar: SeekBar) {
-                }
+            override fun onStartTrackingTouch(seekBar: SeekBar) {
+            }
 
-                override fun onStopTrackingTouch(seekBar: SeekBar) {
-                }
-            })
+            override fun onStopTrackingTouch(seekBar: SeekBar) {
+            }
+        })
         val btClearUserCache = view.findViewById<Button>(R.id.bt_clear_user_cache)
         btClearUserCache.setOnClickListener {
             onClickCache(getString(R.string.confirm_clear_user_cache)) {
@@ -93,7 +91,7 @@ class SettingsFragment : Fragment() {
     }
 
     private fun observeCurrentUser(view: View) {
-        userViewModel.currentUser.observe(activity!!, Observer { user ->
+        userViewModel.currentUser.observe(viewLifecycleOwner, Observer { user ->
             if (user != null && user.isSampleUser()) {
                 val cacheLayout = view.findViewById<RelativeLayout>(R.id.cache_layout)
                 cacheLayout.visibility = View.INVISIBLE
@@ -102,7 +100,7 @@ class SettingsFragment : Fragment() {
     }
 
     private fun observeSeekBarProgress() {
-        settingsViewModel.seekBarProgress.observe(this, Observer { sk ->
+        settingsViewModel.seekBarProgress.observe(viewLifecycleOwner, Observer { sk ->
             sk?.let {
                 val seekBarProgress = if (it == 0) 1 else it
                 seekBar.post {
@@ -114,7 +112,7 @@ class SettingsFragment : Fragment() {
     }
 
     private fun observeClearCache() {
-        userViewModel.clearCache.observe(this, Observer { event ->
+        userViewModel.clearCache.observe(viewLifecycleOwner, Observer { event ->
             event?.getContentIfNotHandled()?.let { result ->
                 val message =
                     if (result) getString(R.string.images_removed) else getString(R.string.images_removed_error)
@@ -124,19 +122,19 @@ class SettingsFragment : Fragment() {
     }
 
     private fun observeAutomaticNextPage(automaticNextPage: Switch) {
-        settingsViewModel.isAutomaticNextPageEnabled.observe(this, Observer {
+        settingsViewModel.isAutomaticNextPageEnabled.observe(viewLifecycleOwner, Observer {
             it?.let { automaticNextPage.isChecked = it }
         })
     }
 
     private fun observeFeedbackSound(feedbackSound: Switch) {
-        settingsViewModel.isFeedbackSoundEnabled.observe(this, Observer {
+        settingsViewModel.isFeedbackSoundEnabled.observe(viewLifecycleOwner, Observer {
             it?.let { feedbackSound.isChecked = it }
         })
     }
 
     private fun observeScanMode(scanMode: Switch) {
-        settingsViewModel.isScanModeEnabled.observe(this, Observer {
+        settingsViewModel.isScanModeEnabled.observe(viewLifecycleOwner, Observer {
             it?.let { scanMode.isChecked = it }
         })
     }

--- a/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
@@ -47,9 +47,7 @@ class SettingsFragment : Fragment() {
         scanMode.setOnCheckedChangeListener { _, isChecked -> settingsViewModel.setScanModeChecked(isChecked) }
         feedbackSound.setOnCheckedChangeListener { _, isChecked -> settingsViewModel.setFeedbackSoundChecked(isChecked) }
         automaticNextPage.setOnCheckedChangeListener { _, isChecked ->
-            settingsViewModel.setAutomaticNextPageChecked(
-                isChecked
-            )
+            settingsViewModel.setAutomaticNextPageChecked(isChecked)
         }
 
         seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {

--- a/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
@@ -119,7 +119,6 @@ class SettingsFragment : Fragment() {
                 )
             }
         }
-
         return view
     }
 

--- a/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
@@ -22,6 +22,9 @@ class SettingsFragment : Fragment() {
 
     private lateinit var seekBar: SeekBar
     private lateinit var seekBarValue: TextView
+    private lateinit var scanMode: Switch
+    private lateinit var feedbackSound: Switch
+    private lateinit var automaticNextPage: Switch
     private lateinit var settingsViewModel: SettingsViewModel
     private lateinit var userViewModel: UserViewModel
 
@@ -33,9 +36,9 @@ class SettingsFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.fragment_settings, container, false)
-        val scanMode = view.findViewById<Switch>(R.id.scan_mode)
-        val feedbackSound = view.findViewById<Switch>(R.id.feedback_sound)
-        val automaticNextPage = view.findViewById<Switch>(R.id.automatic_next_page)
+        scanMode = view.findViewById(R.id.scan_mode)
+        feedbackSound = view.findViewById(R.id.feedback_sound)
+        automaticNextPage = view.findViewById(R.id.automatic_next_page)
         seekBarValue = view.findViewById(R.id.seekbar_value) as TextView
         seekBar = view.findViewById(R.id.seekBar) as SeekBar
 
@@ -79,9 +82,9 @@ class SettingsFragment : Fragment() {
         }
         setHasOptionsMenu(true)
 
-        observeScanMode(scanMode)
-        observeFeedbackSound(feedbackSound)
-        observeAutomaticNextPage(automaticNextPage)
+        observeScanMode()
+        observeFeedbackSound()
+        observeAutomaticNextPage()
         observeClearCache()
         observeSeekBarProgress()
         observeCurrentUser(view)
@@ -119,21 +122,24 @@ class SettingsFragment : Fragment() {
         })
     }
 
-    private fun observeAutomaticNextPage(automaticNextPage: Switch) {
-        settingsViewModel.isAutomaticNextPageEnabled.observe(viewLifecycleOwner, Observer {
-            it?.let { automaticNextPage.isChecked = it }
+    private fun observeAutomaticNextPage() {
+        settingsViewModel.isAutomaticNextPageEnabled.observe(viewLifecycleOwner, Observer { isEnabled ->
+            automaticNextPage.isChecked = isEnabled
         })
     }
 
-    private fun observeFeedbackSound(feedbackSound: Switch) {
-        settingsViewModel.isFeedbackSoundEnabled.observe(viewLifecycleOwner, Observer {
-            it?.let { feedbackSound.isChecked = it }
+    private fun observeFeedbackSound() {
+        settingsViewModel.isFeedbackSoundEnabled.observe(viewLifecycleOwner, Observer { isEnabled ->
+            feedbackSound.isChecked = isEnabled
         })
     }
 
-    private fun observeScanMode(scanMode: Switch) {
-        settingsViewModel.isScanModeEnabled.observe(viewLifecycleOwner, Observer {
-            it?.let { scanMode.isChecked = it }
+    private fun observeScanMode() {
+        settingsViewModel.isScanModeEnabled.observe(viewLifecycleOwner, Observer { isEnabled ->
+            scanMode.isChecked = isEnabled
+            automaticNextPage.isEnabled = isEnabled
+            feedbackSound.isEnabled = isEnabled
+            seekBar.isEnabled = isEnabled
         })
     }
 

--- a/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
@@ -4,13 +4,12 @@ import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v4.app.Fragment
-import android.support.v7.app.AlertDialog
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.*
 import org.falaeapp.falae.R
-import org.falaeapp.falae.loadDefaultShowListener
+import org.falaeapp.falae.util.Util
 import org.falaeapp.falae.viewmodel.SettingsViewModel
 
 class SettingsFragment : Fragment() {
@@ -86,43 +85,41 @@ class SettingsFragment : Fragment() {
                     }
                 })
         setHasOptionsMenu(true)
+        context?.let { context ->
+            val btClearUserCache = view.findViewById<Button>(R.id.bt_clear_user_cache)
+            btClearUserCache.setOnClickListener {
+                Util.createDialog(context = context,
+                        message = getString(R.string.confirm_clear_cache),
+                        positiveText = getString(R.string.yes_option),
+                        positiveClick = {
+                            val message = if (true)
+                                getString(R.string.public_images_removed)
+                            else
+                                getString(R.string.public_images_removed_error)
 
-        val btClearUserCache = view.findViewById<Button>(R.id.bt_clear_user_cache)
-        btClearUserCache.setOnClickListener {
-            val confirmBuilder = AlertDialog.Builder(activity!!)
-            val confirmDialog = confirmBuilder.setTitle(getString(R.string.clear_cache))
-                    .setMessage(getString(R.string.confirm_clear_cache))
-                    .setPositiveButton(getString(R.string.yes_option)) { _, _ ->
-                        val message = if (true)//mListener.clearPublicCache())
-                            getString(R.string.public_images_removed)
-                        else
-                            getString(R.string.public_images_removed_error)
+                            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                        },
+                        negativeText = getString(R.string.no_option)
+                )
+            }
+            val btClearPublicCache = view.findViewById<Button>(R.id.bt_clear_public_cache)
+            btClearPublicCache.setOnClickListener {
+                Util.createDialog(context = context,
+                        message = getString(R.string.confirm_clear_cache),
+                        positiveText = getString(R.string.yes_option),
+                        positiveClick = {
+                            val message = if (true)
+                                getString(R.string.public_images_removed)
+                            else
+                                getString(R.string.public_images_removed_error)
 
-                        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-                    }
-                    .setNegativeButton(getString(R.string.no_option)) { _, _ -> }
-                    .create()
-            confirmDialog.loadDefaultShowListener(resources)
-            confirmDialog.show()
+                            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                        },
+                        negativeText = getString(R.string.no_option)
+                )
+            }
         }
-        val btClearPublicCache = view.findViewById<Button>(R.id.bt_clear_public_cache)
-        btClearPublicCache.setOnClickListener {
-            val confirmBuilder = AlertDialog.Builder(activity!!)
-            val confirmDialog = confirmBuilder.setTitle(getString(R.string.clear_cache))
-                    .setMessage(getString(R.string.confirm_clear_cache))
-                    .setPositiveButton(getString(R.string.yes_option)) { _, _ ->
-                        val message = if (true)//mListener.clearPublicCache())
-                            getString(R.string.public_images_removed)
-                        else
-                            getString(R.string.public_images_removed_error)
 
-                        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-                    }
-                    .setNegativeButton(getString(R.string.no_option)) { _, _ -> }
-                    .create()
-            confirmDialog.loadDefaultShowListener(resources)
-            confirmDialog.show()
-        }
         return view
     }
 

--- a/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
@@ -1,9 +1,6 @@
 package org.falaeapp.falae.fragment
 
-import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
-import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,6 +10,9 @@ import android.widget.SeekBar
 import android.widget.Switch
 import android.widget.TextView
 import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import org.falaeapp.falae.R
 import org.falaeapp.falae.util.Util
 import org.falaeapp.falae.viewmodel.SettingsViewModel
@@ -27,8 +27,8 @@ class SettingsFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        settingsViewModel = ViewModelProviders.of(activity!!).get(SettingsViewModel::class.java)
-        userViewModel = ViewModelProviders.of(activity!!).get(UserViewModel::class.java)
+        settingsViewModel = ViewModelProvider(activity!!).get(SettingsViewModel::class.java)
+        userViewModel = ViewModelProvider(activity!!).get(UserViewModel::class.java)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
@@ -88,7 +88,7 @@ class SettingsFragment : Fragment() {
         context?.let { context ->
             val btClearUserCache = view.findViewById<Button>(R.id.bt_clear_user_cache)
             btClearUserCache.setOnClickListener {
-                Util.createDialog(context = context,
+                val dialog = Util.createDialog(context = context,
                         message = getString(R.string.confirm_clear_cache),
                         positiveText = getString(R.string.yes_option),
                         positiveClick = {
@@ -101,10 +101,11 @@ class SettingsFragment : Fragment() {
                         },
                         negativeText = getString(R.string.no_option)
                 )
+                dialog.show()
             }
             val btClearPublicCache = view.findViewById<Button>(R.id.bt_clear_public_cache)
             btClearPublicCache.setOnClickListener {
-                Util.createDialog(context = context,
+                val dialog = Util.createDialog(context = context,
                         message = getString(R.string.confirm_clear_cache),
                         positiveText = getString(R.string.yes_option),
                         positiveClick = {
@@ -117,6 +118,7 @@ class SettingsFragment : Fragment() {
                         },
                         negativeText = getString(R.string.no_option)
                 )
+                dialog.show()
             }
         }
         return view

--- a/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SettingsFragment.kt
@@ -4,13 +4,13 @@ import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.support.v7.app.AlertDialog
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.SeekBar
-import android.widget.Switch
-import android.widget.TextView
+import android.widget.*
 import org.falaeapp.falae.R
+import org.falaeapp.falae.loadDefaultShowListener
 import org.falaeapp.falae.viewmodel.SettingsViewModel
 
 class SettingsFragment : Fragment() {
@@ -86,6 +86,43 @@ class SettingsFragment : Fragment() {
                     }
                 })
         setHasOptionsMenu(true)
+
+        val btClearUserCache = view.findViewById<Button>(R.id.bt_clear_user_cache)
+        btClearUserCache.setOnClickListener {
+            val confirmBuilder = AlertDialog.Builder(activity!!)
+            val confirmDialog = confirmBuilder.setTitle(getString(R.string.clear_cache))
+                    .setMessage(getString(R.string.confirm_clear_cache))
+                    .setPositiveButton(getString(R.string.yes_option)) { _, _ ->
+                        val message = if (true)//mListener.clearPublicCache())
+                            getString(R.string.public_images_removed)
+                        else
+                            getString(R.string.public_images_removed_error)
+
+                        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                    }
+                    .setNegativeButton(getString(R.string.no_option)) { _, _ -> }
+                    .create()
+            confirmDialog.loadDefaultShowListener(resources)
+            confirmDialog.show()
+        }
+        val btClearPublicCache = view.findViewById<Button>(R.id.bt_clear_public_cache)
+        btClearPublicCache.setOnClickListener {
+            val confirmBuilder = AlertDialog.Builder(activity!!)
+            val confirmDialog = confirmBuilder.setTitle(getString(R.string.clear_cache))
+                    .setMessage(getString(R.string.confirm_clear_cache))
+                    .setPositiveButton(getString(R.string.yes_option)) { _, _ ->
+                        val message = if (true)//mListener.clearPublicCache())
+                            getString(R.string.public_images_removed)
+                        else
+                            getString(R.string.public_images_removed_error)
+
+                        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                    }
+                    .setNegativeButton(getString(R.string.no_option)) { _, _ -> }
+                    .create()
+            confirmDialog.loadDefaultShowListener(resources)
+            confirmDialog.show()
+        }
         return view
     }
 

--- a/app/src/main/java/org/falaeapp/falae/fragment/SpreadSheetFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SpreadSheetFragment.kt
@@ -1,11 +1,6 @@
 package org.falaeapp.falae.fragment
 
-import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
-import android.support.v4.app.Fragment
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -13,6 +8,11 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import org.falaeapp.falae.R
 import org.falaeapp.falae.adapter.SpreadSheetAdapter
 import org.falaeapp.falae.model.SpreadSheet
@@ -27,14 +27,14 @@ class SpreadSheetFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        onAttachFragment(parentFragment)
+        onAttachFragment(parentFragment!!)
         setHasOptionsMenu(true)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val view = inflater.inflate(R.layout.fragment_spread_sheet, container, false)
         val recyclerView = view.findViewById(R.id.spreadsheet_recycler) as RecyclerView
-        userViewModel = ViewModelProviders.of(activity!!).get(UserViewModel::class.java)
+        userViewModel = ViewModelProvider(activity!!).get(UserViewModel::class.java)
         userViewModel.currentUser.observe(activity!!, Observer { user ->
             user?.let {
                 spreadSheetAdapter = SpreadSheetAdapter(context, it.spreadsheets) { spreadSheet ->
@@ -47,23 +47,23 @@ class SpreadSheetFragment : Fragment() {
                 recyclerView.adapter = spreadSheetAdapter
             }
         })
-        val layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
+        val layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
         recyclerView.layoutManager = layoutManager
         return view
     }
 
-    override fun onAttachFragment(fragment: Fragment?) {
+    override fun onAttachFragment(fragment: Fragment) {
         if (fragment is SpreadSheetFragmentListener) {
             mListener = fragment
         } else {
-            throw RuntimeException(fragment!!.toString() + " must implement SpreadSheetFragmentListener")
+            throw RuntimeException("$fragment must implement SpreadSheetFragmentListener")
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater?) {
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         userViewModel.currentUser.observe(activity!!, Observer { user ->
             if (user != null && !user.isSampleUser()) {
-                inflater?.inflate(R.menu.board_menu, menu)
+                inflater.inflate(R.menu.board_menu, menu)
             }
         })
     }

--- a/app/src/main/java/org/falaeapp/falae/fragment/SpreadSheetFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SpreadSheetFragment.kt
@@ -6,14 +6,18 @@ import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
-import android.view.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
 import android.widget.Toast
 import org.falaeapp.falae.R
 import org.falaeapp.falae.adapter.SpreadSheetAdapter
 import org.falaeapp.falae.model.SpreadSheet
 import org.falaeapp.falae.util.Util
 import org.falaeapp.falae.viewmodel.UserViewModel
-
 
 class SpreadSheetFragment : Fragment() {
 
@@ -58,7 +62,7 @@ class SpreadSheetFragment : Fragment() {
 
     override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater?) {
         userViewModel.currentUser.observe(activity!!, Observer { user ->
-            if (user != null && user.email.contains(EMAIL_SAMPLE).not()) {
+            if (user != null && !user.isSampleUser()) {
                 inflater?.inflate(R.menu.board_menu, menu)
             }
         })
@@ -69,12 +73,12 @@ class SpreadSheetFragment : Fragment() {
             R.id.remove_item -> {
                 context?.let { context ->
                     Util.createDialog(
-                            context = context,
-                            title = getString(R.string.removeUser),
-                            message = getString(R.string.questionRemoveUser),
-                            positiveText = getString(R.string.yes_option),
-                            positiveClick = { userViewModel.removeUser() },
-                            negativeText = getString(R.string.no_option)
+                        context = context,
+                        title = getString(R.string.removeUser),
+                        message = getString(R.string.questionRemoveUser),
+                        positiveText = getString(R.string.yes_option),
+                        positiveClick = { userViewModel.removeUser() },
+                        negativeText = getString(R.string.no_option)
                     ).show()
                 }
                 return true
@@ -90,7 +94,6 @@ class SpreadSheetFragment : Fragment() {
     companion object {
 
         private const val USER_PARAM = "userParam"
-        private const val EMAIL_SAMPLE = "@falaeapp.org"
 
         fun newInstance(): SpreadSheetFragment {
             return SpreadSheetFragment()

--- a/app/src/main/java/org/falaeapp/falae/fragment/SpreadSheetFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SpreadSheetFragment.kt
@@ -61,7 +61,7 @@ class SpreadSheetFragment : Fragment() {
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        userViewModel.currentUser.observe(activity!!, Observer { user ->
+        userViewModel.currentUser.observe(viewLifecycleOwner, Observer { user ->
             if (user != null && !user.isSampleUser()) {
                 inflater.inflate(R.menu.board_menu, menu)
             }
@@ -92,8 +92,6 @@ class SpreadSheetFragment : Fragment() {
     }
 
     companion object {
-
-        private const val USER_PARAM = "userParam"
 
         fun newInstance(): SpreadSheetFragment {
             return SpreadSheetFragment()

--- a/app/src/main/java/org/falaeapp/falae/fragment/SpreadSheetFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SpreadSheetFragment.kt
@@ -35,7 +35,7 @@ class SpreadSheetFragment : Fragment() {
         val view = inflater.inflate(R.layout.fragment_spread_sheet, container, false)
         val recyclerView = view.findViewById(R.id.spreadsheet_recycler) as RecyclerView
         userViewModel = ViewModelProvider(activity!!).get(UserViewModel::class.java)
-        userViewModel.currentUser.observe(activity!!, Observer { user ->
+        userViewModel.currentUser.observe(viewLifecycleOwner, Observer { user ->
             user?.let {
                 spreadSheetAdapter = SpreadSheetAdapter(context, it.spreadsheets) { spreadSheet ->
                     spreadSheet.initialPage?.let {

--- a/app/src/main/java/org/falaeapp/falae/fragment/SyncUserFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SyncUserFragment.kt
@@ -123,7 +123,7 @@ class SyncUserFragment : Fragment() {
         if (cancel) {
             focusView?.requestFocus()
         } else {
-            userViewModel.login(email, password)
+            userViewModel.synchronizeUser(email, password)
             pDialog?.show()
         }
     }

--- a/app/src/main/java/org/falaeapp/falae/fragment/SyncUserFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SyncUserFragment.kt
@@ -61,7 +61,7 @@ class SyncUserFragment : Fragment() {
         })
         pDialog = ProgressDialog(context)
         pDialog?.apply {
-            setMessage(context?.getString(R.string.synchronize_message))
+            setMessage(context.getString(R.string.synchronize_message))
             isIndeterminate = false
             setCancelable(false)
         }

--- a/app/src/main/java/org/falaeapp/falae/fragment/SyncUserFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SyncUserFragment.kt
@@ -34,7 +34,7 @@ class SyncUserFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         userViewModel = ViewModelProvider(activity!!).get(UserViewModel::class.java)
-        userViewModel.reposResult.observe(this, Observer { event ->
+        userViewModel.syncAccountResponse.observe(this, Observer { event ->
             event?.getContentIfNotHandled()?.let { result ->
                 result.second?.let { error ->
                     onError(error)

--- a/app/src/main/java/org/falaeapp/falae/fragment/SyncUserFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/SyncUserFragment.kt
@@ -1,11 +1,8 @@
 package org.falaeapp.falae.fragment
 
 import android.app.ProgressDialog
-import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.os.Bundle
-import android.support.v4.app.Fragment
 import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
@@ -16,6 +13,9 @@ import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
 import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import com.android.volley.AuthFailureError
 import org.falaeapp.falae.R
 import org.falaeapp.falae.exception.UserNotFoundException
@@ -33,7 +33,7 @@ class SyncUserFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        userViewModel = ViewModelProviders.of(activity!!).get(UserViewModel::class.java)
+        userViewModel = ViewModelProvider(activity!!).get(UserViewModel::class.java)
         userViewModel.reposResult.observe(this, Observer { event ->
             event?.getContentIfNotHandled()?.let { result ->
                 result.second?.let { error ->
@@ -71,12 +71,12 @@ class SyncUserFragment : Fragment() {
         return view
     }
 
-    override fun onAttach(context: Context?) {
+    override fun onAttach(context: Context) {
         super.onAttach(context)
         if (context is SyncUserFragmentListener) {
             mListener = context
         } else {
-            throw RuntimeException(context!!.toString() + " must implement SyncUserFragmentListener")
+            throw RuntimeException("$context must implement SyncUserFragmentListener")
         }
     }
 

--- a/app/src/main/java/org/falaeapp/falae/fragment/TabPagerFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/TabPagerFragment.kt
@@ -2,11 +2,11 @@ package org.falaeapp.falae.fragment
 
 import android.content.Context
 import android.os.Bundle
-import android.support.design.widget.TabLayout
-import android.support.v4.app.Fragment
-import android.support.v4.app.FragmentManager
-import android.support.v4.app.FragmentStatePagerAdapter
-import android.support.v4.view.ViewPager
+import com.google.android.material.tabs.TabLayout
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentStatePagerAdapter
+import androidx.viewpager.widget.ViewPager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -31,12 +31,12 @@ class TabPagerFragment : Fragment(), SpreadSheetFragment.SpreadSheetFragmentList
         return view
     }
 
-    override fun onAttach(context: Context?) {
+    override fun onAttach(context: Context) {
         super.onAttach(context)
         if (context is TabPagerFragmentListener) {
             mListener = context
         } else {
-            throw RuntimeException(context!!.toString() + " must implement TabPagerFragment")
+            throw RuntimeException("$context must implement TabPagerFragment")
         }
     }
 

--- a/app/src/main/java/org/falaeapp/falae/fragment/TabPagerFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/TabPagerFragment.kt
@@ -2,14 +2,14 @@ package org.falaeapp.falae.fragment
 
 import android.content.Context
 import android.os.Bundle
-import com.google.android.material.tabs.TabLayout
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
 import androidx.viewpager.widget.ViewPager
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import com.google.android.material.tabs.TabLayout
 import org.falaeapp.falae.R
 import org.falaeapp.falae.model.SpreadSheet
 
@@ -18,8 +18,10 @@ class TabPagerFragment : Fragment(), SpreadSheetFragment.SpreadSheetFragmentList
     private lateinit var mListener: TabPagerFragmentListener
     private lateinit var viewPager: ViewPager
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
-                              savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         val view = inflater.inflate(R.layout.fragment_tab_pager, container, false)
         viewPager = view.findViewById(R.id.viewpager) as ViewPager
         viewPager.adapter = CustomFragmentPagerAdapter(childFragmentManager, context)
@@ -48,8 +50,10 @@ class TabPagerFragment : Fragment(), SpreadSheetFragment.SpreadSheetFragmentList
         fun displayActivity(spreadSheet: SpreadSheet)
     }
 
-    inner class CustomFragmentPagerAdapter(fm: FragmentManager, private val context: Context?) : FragmentStatePagerAdapter(fm) {
-        private val tabTitles = arrayOf(resources.getString(R.string.spreadsheets), resources.getString(R.string.user_info))
+    inner class CustomFragmentPagerAdapter(fm: FragmentManager, private val context: Context?) :
+        FragmentStatePagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+        private val tabTitles =
+            arrayOf(resources.getString(R.string.spreadsheets), resources.getString(R.string.user_info))
 
         override fun getItem(position: Int): Fragment {
             return if (position == 0) {

--- a/app/src/main/java/org/falaeapp/falae/fragment/UserInfoFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/UserInfoFragment.kt
@@ -1,16 +1,16 @@
 package org.falaeapp.falae.fragment
 
-import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
-import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import com.squareup.picasso.MemoryPolicy
 import com.squareup.picasso.Picasso
 import jp.wasabeef.picasso.transformations.CropCircleTransformation
@@ -23,8 +23,8 @@ class UserInfoFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        userViewModel = ViewModelProviders.of(activity!!).get(UserViewModel::class.java)
-        onAttachFragment(parentFragment)
+        userViewModel = ViewModelProvider(activity!!).get(UserViewModel::class.java)
+        onAttachFragment(parentFragment!!)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,

--- a/app/src/main/java/org/falaeapp/falae/fragment/UserInfoFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/UserInfoFragment.kt
@@ -27,8 +27,10 @@ class UserInfoFragment : Fragment() {
         onAttachFragment(parentFragment!!)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
-                              savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         // Inflate the layout for this fragment
         val view = inflater.inflate(R.layout.fragment_user_info, container, false)
         val imageView = view.findViewById(R.id.user_photo) as ImageView
@@ -46,17 +48,17 @@ class UserInfoFragment : Fragment() {
             placeHolderImage = context?.getDrawable(R.drawable.ic_person_black_24dp)
         }
 
-        userViewModel.currentUser.observe(activity!!, Observer { user ->
+        userViewModel.currentUser.observe(viewLifecycleOwner, Observer { user ->
             user?.apply {
-                photo?.let {linkPhoto ->
+                photo?.let { linkPhoto ->
                     if (linkPhoto.isNotEmpty() && context != null) {
                         Picasso.get()
-                                .load(linkPhoto)
-                                .placeholder(placeHolderImage!!)
-                                .error(brokenImage!!)
-                                .transform(CropCircleTransformation())
-                                .memoryPolicy(MemoryPolicy.NO_CACHE)
-                                .into(imageView)
+                            .load(linkPhoto)
+                            .placeholder(placeHolderImage!!)
+                            .error(brokenImage!!)
+                            .transform(CropCircleTransformation())
+                            .memoryPolicy(MemoryPolicy.NO_CACHE)
+                            .into(imageView)
                     }
                 }
                 userName.text = name

--- a/app/src/main/java/org/falaeapp/falae/fragment/ViewPagerItemFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/ViewPagerItemFragment.kt
@@ -32,7 +32,7 @@ import java.util.Timer
 import java.util.TimerTask
 import kotlin.math.roundToInt
 
-class ViewPagerItemFragment : Fragment(), FragmentLifecycle {
+class ViewPagerItemFragment : Fragment() {
     private var mItems: List<Item> = emptyList()
     private var mItemsLayout: List<FrameLayout> = emptyList()
     private lateinit var mListener: ViewPagerItemFragmentListener
@@ -87,7 +87,6 @@ class ViewPagerItemFragment : Fragment(), FragmentLifecycle {
         }
         observeFeedbackSound()
         observeAutomaticNextPage()
-        observeScanMode()
         return view
     }
 
@@ -113,16 +112,13 @@ class ViewPagerItemFragment : Fragment(), FragmentLifecycle {
         })
     }
 
+    override fun onResume() {
+        super.onResume()
+        observeScanMode()
+    }
+
     override fun onPause() {
         super.onPause()
-        stopPageScan()
-    }
-
-    override fun onResumeFragment() {
-        doPageScan()
-    }
-
-    override fun onPauseFragment() {
         stopPageScan()
     }
 

--- a/app/src/main/java/org/falaeapp/falae/fragment/ViewPagerItemFragment.kt
+++ b/app/src/main/java/org/falaeapp/falae/fragment/ViewPagerItemFragment.kt
@@ -1,7 +1,5 @@
 package org.falaeapp.falae.fragment
 
-import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.graphics.Color
 import android.graphics.Point
@@ -9,9 +7,6 @@ import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
 import android.os.Build
 import android.os.Bundle
-import android.support.constraint.ConstraintLayout
-import android.support.v4.app.Fragment
-import android.support.v7.widget.GridLayout
 import android.util.DisplayMetrics
 import android.util.Log
 import android.view.LayoutInflater
@@ -21,13 +16,20 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.fragment.app.Fragment
+import androidx.gridlayout.widget.GridLayout
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import com.squareup.picasso.Picasso
 import org.falaeapp.falae.R
 import org.falaeapp.falae.model.Category
 import org.falaeapp.falae.model.Item
 import org.falaeapp.falae.viewmodel.DisplayViewModel
 import org.falaeapp.falae.viewmodel.SettingsViewModel
-import java.util.*
+import java.util.ArrayList
+import java.util.Timer
+import java.util.TimerTask
 
 class ViewPagerItemFragment : Fragment(), FragmentLifecycle {
     private var mItems: List<Item> = emptyList()
@@ -55,10 +57,10 @@ class ViewPagerItemFragment : Fragment(), FragmentLifecycle {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        displayViewModel = ViewModelProviders.of(activity!!).get(DisplayViewModel::class.java)
-        settingsViewModel = ViewModelProviders.of(activity!!).get(SettingsViewModel::class.java)
+        displayViewModel = ViewModelProvider(activity!!).get(DisplayViewModel::class.java)
+        settingsViewModel = ViewModelProvider(activity!!).get(SettingsViewModel::class.java)
         arguments?.let { arguments ->
-            mItems = arguments.getParcelableArrayList(ITEMS_PARAM)
+            mItems = arguments.getParcelableArrayList(ITEMS_PARAM) ?: emptyList()
             mColumns = arguments.getInt(COLUMNS_PARAM)
             mRows = arguments.getInt(ROWS_PARAM)
             mMarginWidth = arguments.getInt(MARGIN_WIDTH)
@@ -270,12 +272,12 @@ class ViewPagerItemFragment : Fragment(), FragmentLifecycle {
         }
     }
 
-    override fun onAttach(context: Context?) {
+    override fun onAttach(context: Context) {
         super.onAttach(context)
         if (context is ViewPagerItemFragmentListener) {
             mListener = context
         } else {
-            throw RuntimeException(context.toString() + " must implement ViewPagerItemFragmentListener")
+            throw RuntimeException("$context must implement ViewPagerItemFragmentListener")
         }
     }
 

--- a/app/src/main/java/org/falaeapp/falae/model/DownloadCache.kt
+++ b/app/src/main/java/org/falaeapp/falae/model/DownloadCache.kt
@@ -10,8 +10,20 @@ import org.falaeapp.falae.room.converter.MutableMapConverter
  */
 @Entity
 data class DownloadCache(
-        @PrimaryKey(autoGenerate = true)
-        var id: Int = 0,
-        val name: String,
-        @TypeConverters(MutableMapConverter::class)
-        val sources: MutableMap<String, String>)
+    @PrimaryKey(autoGenerate = true)
+    var id: Int = 0,
+    val name: String,
+    @TypeConverters(MutableMapConverter::class)
+    val sources: MutableMap<String, String>
+) {
+
+    fun store(key: String, value: String) {
+        if (value.isNotEmpty()) {
+            if (!sources.containsKey(key)) {
+                sources[key] = value
+            }
+        } else {
+            sources.remove(key)
+        }
+    }
+}

--- a/app/src/main/java/org/falaeapp/falae/model/DownloadCache.kt
+++ b/app/src/main/java/org/falaeapp/falae/model/DownloadCache.kt
@@ -1,8 +1,8 @@
 package org.falaeapp.falae.model
 
-import android.arch.persistence.room.Entity
-import android.arch.persistence.room.PrimaryKey
-import android.arch.persistence.room.TypeConverters
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.TypeConverters
 import org.falaeapp.falae.room.converter.MutableMapConverter
 
 /**

--- a/app/src/main/java/org/falaeapp/falae/model/User.kt
+++ b/app/src/main/java/org/falaeapp/falae/model/User.kt
@@ -15,17 +15,32 @@ import org.falaeapp.falae.room.converter.SpreadSheetConverter
 @Parcelize
 @Entity
 data class User(
-        @PrimaryKey(autoGenerate = true)
-        var id: Int = 0,
-        var name: String,
-        @Ignore
-        val authToken: String = "",
-        var email: String,
-        @TypeConverters(SpreadSheetConverter::class)
-        var spreadsheets: List<SpreadSheet> = emptyList(),
-        var profile: String? = "",
-        var photo: String? = "") : Parcelable {
+    @PrimaryKey(autoGenerate = true)
+    var id: Int = 0,
+    var name: String,
+    @Ignore
+    val authToken: String = "",
+    var email: String,
+    @TypeConverters(SpreadSheetConverter::class)
+    var spreadsheets: List<SpreadSheet> = emptyList(),
+    var profile: String? = "",
+    var photo: String? = ""
+) : Parcelable {
     constructor() : this(
-            0, "", "", "", emptyList(), "", ""
+        0, "", "", "", emptyList(), "", ""
     )
+
+    fun getItemsFromAllSpreadsheets(): List<Item> {
+        return spreadsheets
+            .flatMap { it.pages }
+            .flatMap { it.items }
+    }
+
+    fun isSampleUser(): Boolean {
+        return email == SAMPLE_USER_EMAIL
+    }
+
+    companion object {
+        private const val SAMPLE_USER_EMAIL = "demo@falaeapp.org"
+    }
 }

--- a/app/src/main/java/org/falaeapp/falae/model/User.kt
+++ b/app/src/main/java/org/falaeapp/falae/model/User.kt
@@ -1,9 +1,9 @@
 package org.falaeapp.falae.model
 
-import android.arch.persistence.room.Entity
-import android.arch.persistence.room.Ignore
-import android.arch.persistence.room.PrimaryKey
-import android.arch.persistence.room.TypeConverters
+import androidx.room.Entity
+import androidx.room.Ignore
+import androidx.room.PrimaryKey
+import androidx.room.TypeConverters
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 import org.falaeapp.falae.room.converter.SpreadSheetConverter

--- a/app/src/main/java/org/falaeapp/falae/repository/SettingsRepository.kt
+++ b/app/src/main/java/org/falaeapp/falae/repository/SettingsRepository.kt
@@ -1,50 +1,52 @@
 package org.falaeapp.falae.repository
 
 import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.falaeapp.falae.fragment.SettingsFragment
 import org.falaeapp.falae.storage.SharedPreferencesUtils
 
 class SettingsRepository(val context: Context) {
     private val sharedPreferences: SharedPreferencesUtils = SharedPreferencesUtils(context.applicationContext)
 
-    fun isScanModeEnabled(): Boolean {
-        return sharedPreferences.getBoolean(SCAN_MODE)
+    suspend fun isScanModeEnabled(): Boolean = withContext(Dispatchers.IO) {
+        sharedPreferences.getBoolean(SCAN_MODE)
     }
 
-    fun isFeedbackSoundEnabled(): Boolean {
-        return sharedPreferences.getBoolean(FEEDBACK_SOUND)
+    suspend fun isFeedbackSoundEnabled(): Boolean = withContext(Dispatchers.IO) {
+        sharedPreferences.getBoolean(FEEDBACK_SOUND)
     }
 
-    fun isAutomaticNextPageEnabled(): Boolean {
-        return sharedPreferences.getBoolean(AUTOMATIC_NEXT_PAGE)
+    suspend fun isAutomaticNextPageEnabled(): Boolean = withContext(Dispatchers.IO) {
+        sharedPreferences.getBoolean(AUTOMATIC_NEXT_PAGE)
     }
 
-    fun saveEnableScanMode(checked: Boolean) {
+    suspend fun saveEnableScanMode(checked: Boolean) = withContext(Dispatchers.IO) {
         sharedPreferences.storeBoolean(SCAN_MODE, checked)
     }
 
-    fun saveEnableFeedbackSound(checked: Boolean) {
+    suspend fun saveEnableFeedbackSound(checked: Boolean) = withContext(Dispatchers.IO) {
         sharedPreferences.storeBoolean(FEEDBACK_SOUND, checked)
     }
 
-    fun saveEnableAutomaticNextPage(checked: Boolean) {
+    suspend fun saveEnableAutomaticNextPage(checked: Boolean) = withContext(Dispatchers.IO) {
         sharedPreferences.storeBoolean(AUTOMATIC_NEXT_PAGE, checked)
     }
 
-    fun saveSeekBarProgress(progress: Int) {
+    suspend fun saveSeekBarProgress(progress: Int) = withContext(Dispatchers.IO) {
         sharedPreferences.storeInt(SEEK_BAR_PROGRESS, progress)
     }
 
-    fun saveScanModeDuration(timeMillis: Long) {
+    suspend fun saveScanModeDuration(timeMillis: Long) = withContext(Dispatchers.IO) {
         sharedPreferences.storeLong(SCAN_MODE_DURATION, timeMillis)
     }
 
-    fun getSeekBarProgress(): Int {
-        return sharedPreferences.getInt(SEEK_BAR_PROGRESS)
+    suspend fun getSeekBarProgress(): Int = withContext(Dispatchers.IO) {
+        sharedPreferences.getInt(SEEK_BAR_PROGRESS)
     }
 
-    fun getScanModeDuration(): Long {
-        return sharedPreferences.getLong(SCAN_MODE_DURATION, 500L)
+    suspend fun getScanModeDuration(): Long = withContext(Dispatchers.IO) {
+        sharedPreferences.getLong(SCAN_MODE_DURATION, 500L)
     }
 
     companion object {
@@ -57,5 +59,4 @@ class SettingsRepository(val context: Context) {
 
         fun newInstance(): SettingsFragment = SettingsFragment()
     }
-
 }

--- a/app/src/main/java/org/falaeapp/falae/repository/UserRepository.kt
+++ b/app/src/main/java/org/falaeapp/falae/repository/UserRepository.kt
@@ -1,6 +1,7 @@
 package org.falaeapp.falae.repository
 
 import android.content.Context
+import androidx.lifecycle.LiveData
 import com.android.volley.AuthFailureError
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -21,7 +22,7 @@ class UserRepository(val context: Context) {
     private val fileHandler: FileHandler = FileHandler()
     private val sharedPreferences: SharedPreferencesUtils = SharedPreferencesUtils(context.applicationContext)
 
-    suspend fun getAllUsers(): List<User> = withContext(Dispatchers.IO) {
+    suspend fun getAllUsers(): LiveData<List<User>> = withContext(Dispatchers.IO) {
         userModelDao.getAllUsers()
     }
 
@@ -29,7 +30,7 @@ class UserRepository(val context: Context) {
         userModelDao.findById(userId)
     }
 
-    suspend fun saveOrUpdateUser(user: User): Long = withContext(Dispatchers.IO) {
+    private suspend fun saveOrUpdateUser(user: User): Long = withContext(Dispatchers.IO) {
         userModelDao.findByEmail(user.email)?.let { result ->
             user.id = result.id
             userModelDao.update(user)
@@ -83,7 +84,7 @@ class UserRepository(val context: Context) {
         sharedPreferences.storeInt(VERSION_CODE, currentVersionCode)
     }
 
-    suspend fun synchAccount(email: String, password: String): User = withContext(Dispatchers.IO) {
+    suspend fun syncAccount(email: String, password: String): User = withContext(Dispatchers.IO) {
         var user = login(email, password)
         user = downloadImages(user)
         val userId = saveOrUpdateUser(user)

--- a/app/src/main/java/org/falaeapp/falae/repository/UserRepository.kt
+++ b/app/src/main/java/org/falaeapp/falae/repository/UserRepository.kt
@@ -3,11 +3,14 @@ package org.falaeapp.falae.repository
 import android.arch.lifecycle.LiveData
 import android.content.Context
 import com.android.volley.AuthFailureError
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.falaeapp.falae.exception.UserNotFoundException
 import org.falaeapp.falae.model.User
 import org.falaeapp.falae.room.AppDatabase
 import org.falaeapp.falae.room.DownloadCacheDao
 import org.falaeapp.falae.service.FalaeWebPlatform
+import org.falaeapp.falae.service.FalaeWebPlatform.Companion.PUBLIC_CACHE_KEY
 import org.falaeapp.falae.storage.FileHandler
 import org.falaeapp.falae.storage.SharedPreferencesUtils
 import org.jetbrains.anko.doAsync
@@ -93,6 +96,16 @@ class UserRepository(val context: Context) {
         }
         // Update the shared preferences with the current version code
         sharedPreferences.storeInt(VERSION_CODE, currentVersionCode)
+    }
+
+    suspend fun clearUserCache(email: String) = withContext(Dispatchers.IO) {
+        downloadCacheDao.remove(email)
+        fileHandler.deleteUserFolder(context, email)
+    }
+
+    suspend fun clearPublicCache() = withContext(Dispatchers.IO) {
+        downloadCacheDao.remove(PUBLIC_CACHE_KEY)
+        fileHandler.deletePublicFolder(context)
     }
 
     companion object {

--- a/app/src/main/java/org/falaeapp/falae/repository/UserRepository.kt
+++ b/app/src/main/java/org/falaeapp/falae/repository/UserRepository.kt
@@ -92,7 +92,7 @@ class UserRepository(val context: Context) {
         user
     }
 
-    suspend fun login(email: String, password: String): User = withContext(Dispatchers.IO) {
+    private suspend fun login(email: String, password: String): User = withContext(Dispatchers.IO) {
         try {
             falaeWebPlatform.login(email, password)
         } catch (exception: Exception) {
@@ -105,7 +105,7 @@ class UserRepository(val context: Context) {
         }
     }
 
-    suspend fun downloadImages(user: User): User = withContext(Dispatchers.IO) {
+    private suspend fun downloadImages(user: User): User = withContext(Dispatchers.IO) {
         try {
             falaeWebPlatform.downloadImages(user, downloadCacheDao, fileHandler)
         } catch (ex: IOException) {

--- a/app/src/main/java/org/falaeapp/falae/repository/UserRepository.kt
+++ b/app/src/main/java/org/falaeapp/falae/repository/UserRepository.kt
@@ -83,6 +83,14 @@ class UserRepository(val context: Context) {
         sharedPreferences.storeInt(VERSION_CODE, currentVersionCode)
     }
 
+    suspend fun synchAccount(email: String, password: String): User = withContext(Dispatchers.IO) {
+        var user = login(email, password)
+        user = downloadImages(user)
+        val userId = saveOrUpdateUser(user)
+        saveLastConnectedUserId(userId)
+        user
+    }
+
     suspend fun login(email: String, password: String): User = withContext(Dispatchers.IO) {
         try {
             falaeWebPlatform.login(email, password)

--- a/app/src/main/java/org/falaeapp/falae/room/DownloadCacheDao.kt
+++ b/app/src/main/java/org/falaeapp/falae/room/DownloadCacheDao.kt
@@ -1,6 +1,6 @@
 package org.falaeapp.falae.room
 
-import android.arch.persistence.room.*
+import androidx.room.*
 import org.falaeapp.falae.model.DownloadCache
 
 @Dao

--- a/app/src/main/java/org/falaeapp/falae/room/UserModelDao.kt
+++ b/app/src/main/java/org/falaeapp/falae/room/UserModelDao.kt
@@ -1,11 +1,11 @@
 package org.falaeapp.falae.room
 
-import android.arch.persistence.room.Dao
-import android.arch.persistence.room.Delete
-import android.arch.persistence.room.Insert
-import android.arch.persistence.room.OnConflictStrategy.REPLACE
-import android.arch.persistence.room.Query
-import android.arch.persistence.room.Update
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy.REPLACE
+import androidx.room.Query
+import androidx.room.Update
 import org.falaeapp.falae.model.User
 
 @Dao

--- a/app/src/main/java/org/falaeapp/falae/room/UserModelDao.kt
+++ b/app/src/main/java/org/falaeapp/falae/room/UserModelDao.kt
@@ -1,10 +1,12 @@
 package org.falaeapp.falae.room
 
-import android.arch.lifecycle.LiveData
-import android.arch.persistence.room.*
+import android.arch.persistence.room.Dao
+import android.arch.persistence.room.Delete
+import android.arch.persistence.room.Insert
 import android.arch.persistence.room.OnConflictStrategy.REPLACE
+import android.arch.persistence.room.Query
+import android.arch.persistence.room.Update
 import org.falaeapp.falae.model.User
-
 
 @Dao
 interface UserModelDao {
@@ -13,10 +15,10 @@ interface UserModelDao {
     fun findByEmail(email: String): User?
 
     @Query("select * from User where id = :id")
-    fun findById(id: Long): LiveData<User>
+    fun findById(id: Long): User
 
     @Query("select * from User")
-    fun getAllUsers(): LiveData<List<User>>
+    fun getAllUsers(): List<User>
 
     @Insert(onConflict = REPLACE)
     fun insert(user: User): Long

--- a/app/src/main/java/org/falaeapp/falae/room/UserModelDao.kt
+++ b/app/src/main/java/org/falaeapp/falae/room/UserModelDao.kt
@@ -1,5 +1,6 @@
 package org.falaeapp.falae.room
 
+import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
@@ -18,7 +19,7 @@ interface UserModelDao {
     fun findById(id: Long): User
 
     @Query("select * from User")
-    fun getAllUsers(): List<User>
+    fun getAllUsers(): LiveData<List<User>>
 
     @Insert(onConflict = REPLACE)
     fun insert(user: User): Long

--- a/app/src/main/java/org/falaeapp/falae/room/converter/MutableMapConverter.kt
+++ b/app/src/main/java/org/falaeapp/falae/room/converter/MutableMapConverter.kt
@@ -3,10 +3,11 @@ package org.falaeapp.falae.room.converter
 import android.arch.persistence.room.TypeConverter
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import java.lang.reflect.Type
 
 object MutableMapConverter {
     private val gson = Gson()
-    val typeOfHashMap = object : TypeToken<MutableMap<String, String?>>() {}.type
+    private val typeOfHashMap: Type = object : TypeToken<MutableMap<String, String?>>() {}.type
 
     @TypeConverter
     @JvmStatic

--- a/app/src/main/java/org/falaeapp/falae/room/converter/MutableMapConverter.kt
+++ b/app/src/main/java/org/falaeapp/falae/room/converter/MutableMapConverter.kt
@@ -1,6 +1,6 @@
 package org.falaeapp.falae.room.converter
 
-import android.arch.persistence.room.TypeConverter
+import androidx.room.TypeConverter
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import java.lang.reflect.Type

--- a/app/src/main/java/org/falaeapp/falae/room/converter/SpreadSheetConverter.kt
+++ b/app/src/main/java/org/falaeapp/falae/room/converter/SpreadSheetConverter.kt
@@ -1,6 +1,6 @@
 package org.falaeapp.falae.room.converter
 
-import android.arch.persistence.room.TypeConverter
+import androidx.room.TypeConverter
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import org.falaeapp.falae.model.SpreadSheet

--- a/app/src/main/java/org/falaeapp/falae/service/FalaeWebPlatform.kt
+++ b/app/src/main/java/org/falaeapp/falae/service/FalaeWebPlatform.kt
@@ -137,7 +137,6 @@ class FalaeWebPlatform(val context: Context) {
         imgSrc: String
     ): String {
         val url = URL(imgSrc)
-        println("Downloading item: $name - $imgSrc")
         Log.d(this.javaClass.name, "Downloading item: $name - $imgSrc")
         try {
             with(url.openConnection()) {

--- a/app/src/main/java/org/falaeapp/falae/service/FalaeWebPlatform.kt
+++ b/app/src/main/java/org/falaeapp/falae/service/FalaeWebPlatform.kt
@@ -203,6 +203,6 @@ class FalaeWebPlatform(val context: Context) {
     companion object {
 
         private const val TIME_OUT = 6000
-        private const val PUBLIC_CACHE_KEY = "public"
+        const val PUBLIC_CACHE_KEY = "public"
     }
 }

--- a/app/src/main/java/org/falaeapp/falae/service/FalaeWebPlatform.kt
+++ b/app/src/main/java/org/falaeapp/falae/service/FalaeWebPlatform.kt
@@ -7,11 +7,15 @@ import android.net.Uri
 import android.os.Build
 import android.util.Log
 import com.android.volley.Response
-import com.android.volley.VolleyError
 import com.android.volley.toolbox.HurlStack
 import com.android.volley.toolbox.Volley
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.falaeapp.falae.BuildConfig
 import org.falaeapp.falae.TLSSocketFactory
+import org.falaeapp.falae.exception.NoNetworkConnectionException
 import org.falaeapp.falae.model.DownloadCache
 import org.falaeapp.falae.model.Item
 import org.falaeapp.falae.model.User
@@ -24,23 +28,13 @@ import org.json.JSONObject
 import java.io.File
 import java.io.IOException
 import java.net.URL
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 
 class FalaeWebPlatform(val context: Context) {
 
-    private val numberOfCores: Int = Runtime.getRuntime().availableProcessors()
-    private var executor: ThreadPoolExecutor? = null
-    private lateinit var userDownloadCache: DownloadCache
-    private lateinit var publicDownloadCache: DownloadCache
-
-    init {
-        initExecutor()
-    }
-
-    fun login(email: String, password: String, onComplete: (User?, VolleyError?) -> Unit) {
-        initExecutor()
+    suspend fun login(email: String, password: String): User = suspendCoroutine { continuation ->
         try {
             val credentials = JSONObject()
             credentials.put("email", email)
@@ -50,108 +44,90 @@ class FalaeWebPlatform(val context: Context) {
             jsonRequest.put("user", credentials)
 
             val url = BuildConfig.BASE_URL + "/login.json"
-            val gsonRequest = GsonRequest(url = url,
+            val request = GsonRequest(url = url,
                 clazz = User::class.java,
                 jsonRequest = jsonRequest,
-                listener = Response.Listener {
-                    onComplete(it, null)
+                listener = Response.Listener { response ->
+                    continuation.resume(response)
                 },
                 errorListener = Response.ErrorListener {
-                    onComplete(null, it)
+                    continuation.resumeWithException(it)
                 })
-
             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
                 Volley.newRequestQueue(
                     context,
                     HurlStack(null, TLSSocketFactory())
-                )
-                    .add(gsonRequest)
+                ).add(request)
             } else {
-                Volley.newRequestQueue(context).add(gsonRequest)
+                Volley.newRequestQueue(context).add(request)
             }
         } catch (e: JSONException) {
-            e.printStackTrace()
+            Log.e(javaClass.name, "Error while parsing response: ${e.message}")
+            continuation.resumeWithException(e)
         }
     }
 
-    private fun initExecutor() {
-        if (executor == null || executor?.isTerminated == true) {
-            executor = ThreadPoolExecutor(
-                numberOfCores * 2,
-                numberOfCores * 2,
-                60L,
-                TimeUnit.SECONDS,
-                LinkedBlockingQueue()
-            )
-        }
-    }
-
-    fun downloadImages(
+    suspend fun downloadImages(
         user: User,
         downloadCacheDao: DownloadCacheDao,
-        fileHandler: FileHandler,
-        onSyncComplete: (user: User) -> Unit
-    ) {
+        fileHandler: FileHandler
+    ): User = withContext(Dispatchers.IO) {
         if (!hasNetworkConnection()) {
-            return
+            throw NoNetworkConnectionException("Could not detect any network connection.")
         }
-        userDownloadCache = loadCache(downloadCacheDao, user.email)
-        publicDownloadCache = loadCache(downloadCacheDao, PUBLIC_CACHE_KEY)
+        val userDownloadCache = loadCache(downloadCacheDao, user.email)
+        val publicDownloadCache = loadCache(downloadCacheDao, PUBLIC_CACHE_KEY)
         val publicFolder = fileHandler.createPublicFolder(context)
         val userFolder = fileHandler.createUserFolder(context, user.email)
-        user.photo?.let {
-            if (it.isNotEmpty()) {
-                val imgSrc = "${BuildConfig.BASE_URL}$it"
-                val file = fileHandler.createImg(userFolder, user.name, imgSrc)
-                val localUri = userDownloadCache.sources[imgSrc] ?: download(file, user.authToken, user.name, imgSrc)
-                storeInCache(localUri, imgSrc, userDownloadCache)
-                user.photo = localUri
-            }
-        }
-        val allItems = user.spreadsheets
-            .flatMap { it.pages }
-            .flatMap { it.items }
-        val duplicatedItems = getDuplicatedItems(allItems)
-        allItems.distinctBy { it.imgSrc }
-            .forEach { item: Item ->
-                executor?.execute {
-                    val imgSrc = "${BuildConfig.BASE_URL}${item.imgSrc}"
-                    val folder: File
-                    val cache: DownloadCache
-                    if (item.private) {
-                        folder = userFolder
-                        cache = userDownloadCache
-                    } else {
-                        folder = publicFolder
-                        cache = publicDownloadCache
-                    }
-                    val file = fileHandler.createImg(folder, item.name, imgSrc)
-                    val localUri = cache.sources[imgSrc] ?: download(file, user.authToken, item.name, imgSrc)
-                    storeInCache(localUri, imgSrc, cache)
-                    // Update imgSrc from duplicated items first
-                    duplicatedItems[item.imgSrc]?.forEach { it.imgSrc = localUri }
-                    // Update imgSrc of iterated item
-                    item.imgSrc = localUri
+
+        user.photo?.let { imgSrc ->
+            launch {
+                if (imgSrc.isNotEmpty()) {
+                    user.photo = fetchImage(imgSrc, user.name, fileHandler, userFolder, userDownloadCache, user)
                 }
             }
-        executor?.shutdown()
-        try {
-            executor?.awaitTermination(java.lang.Long.MAX_VALUE, TimeUnit.NANOSECONDS)
-        } catch (e: InterruptedException) {
-            e.printStackTrace()
+        }
+        val allItems = user.getItemsFromAllSpreadsheets()
+        val repeatedItems = getRepeatedItems(allItems)
+        coroutineScope {
+            allItems.distinctBy { it.imgSrc }
+                .forEach { item: Item ->
+                    launch {
+                        val folder: File
+                        val cache: DownloadCache
+                        if (item.private) {
+                            folder = userFolder
+                            cache = userDownloadCache
+                        } else {
+                            folder = publicFolder
+                            cache = publicDownloadCache
+                        }
+                        val localUri = fetchImage(item.imgSrc, item.name, fileHandler, folder, cache, user)
+                        // Update imgSrc from duplicated items first
+                        repeatedItems[item.imgSrc]?.forEach { it.imgSrc = localUri }
+                        // Update imgSrc of iterated item
+                        item.imgSrc = localUri
+                    }
+                }
         }
         saveOrUpdateCache(downloadCacheDao, userDownloadCache)
         saveOrUpdateCache(downloadCacheDao, publicDownloadCache)
-
-        onSyncComplete(user)
+        user
     }
 
-    private fun storeInCache(localUri: String, imgSrc: String, cache: DownloadCache) {
-        if (localUri.isNotEmpty() && !cache.sources.containsKey(imgSrc)) {
-            cache.sources[imgSrc] = localUri
-        } else {
-            cache.sources.remove(imgSrc)
-        }
+    private fun fetchImage(
+        relativeImgPath: String,
+        imgName: String,
+        fileHandler: FileHandler,
+        folder: File,
+        cache: DownloadCache,
+        user: User
+    ): String {
+        val imgSrc = "${BuildConfig.BASE_URL}${relativeImgPath}"
+        val file = fileHandler.createImg(folder, imgName, imgSrc)
+        val localUri = cache.sources[imgSrc] ?: download(file, user.authToken, imgName, imgSrc)
+        cache.store(imgSrc, localUri)
+        return localUri
     }
 
     private fun download(
@@ -178,10 +154,10 @@ class FalaeWebPlatform(val context: Context) {
         return ""
     }
 
-    private fun getDuplicatedItems(list: List<Item>): Map<String, MutableList<Item>> {
+    private fun getRepeatedItems(items: List<Item>): Map<String, MutableList<Item>> {
         val itemsMap = mutableMapOf<String, MutableList<Item>>()
         val uniqueItems = HashSet<String>()
-        list.forEach { item ->
+        items.forEach { item ->
             if (!uniqueItems.add(item.imgSrc)) {
                 val listItem = itemsMap[item.imgSrc] ?: mutableListOf()
                 listItem.add(item)
@@ -192,17 +168,17 @@ class FalaeWebPlatform(val context: Context) {
     }
 
     private fun loadCache(downloadCacheDao: DownloadCacheDao, key: String) =
-        downloadCacheDao.findByName(key)
-            ?: DownloadCache(name = key, sources = mutableMapOf())
+        downloadCacheDao.findByName(key) ?: DownloadCache(name = key, sources = mutableMapOf())
 
-    private fun saveOrUpdateCache(downloadCacheDao: DownloadCacheDao, cache: DownloadCache) {
-        Log.d(javaClass.name, "Saving ${cache.sources.size} images in ${cache.name} folder.")
-        if (!downloadCacheDao.cacheExists(cache.name)) {
-            downloadCacheDao.insert(cache)
-        } else {
-            downloadCacheDao.update(cache)
+    private suspend fun saveOrUpdateCache(downloadCacheDao: DownloadCacheDao, cache: DownloadCache) =
+        withContext(Dispatchers.IO) {
+            Log.d(javaClass.name, "Saving ${cache.sources.size} images in ${cache.name} folder.")
+            if (!downloadCacheDao.cacheExists(cache.name)) {
+                downloadCacheDao.insert(cache)
+            } else {
+                downloadCacheDao.update(cache)
+            }
         }
-    }
 
     private fun hasNetworkConnection(): Boolean {
         val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager

--- a/app/src/main/java/org/falaeapp/falae/service/TextToSpeechService.kt
+++ b/app/src/main/java/org/falaeapp/falae/service/TextToSpeechService.kt
@@ -10,8 +10,8 @@ import android.graphics.Color
 import android.os.Build
 import android.os.IBinder
 import android.speech.tts.TextToSpeech
-import android.support.annotation.RequiresApi
-import android.support.v4.app.NotificationCompat
+import androidx.annotation.RequiresApi
+import androidx.core.app.NotificationCompat
 import java.util.*
 
 

--- a/app/src/main/java/org/falaeapp/falae/storage/FileHandler.kt
+++ b/app/src/main/java/org/falaeapp/falae/storage/FileHandler.kt
@@ -9,8 +9,6 @@ import java.io.File
  */
 class FileHandler {
 
-    private val PUBLIC_IMAGES_PATH = "public_images"
-
     fun createPublicFolder(context: Context?): File {
         val folder = File(context?.filesDir, PUBLIC_IMAGES_PATH)
         if (folder.exists().not()) {
@@ -33,8 +31,12 @@ class FileHandler {
     }
 
     fun deleteUserFolder(context: Context, folderName: String) =
-            File(context.filesDir, folderName).deleteRecursively()
+        File(context.filesDir, folderName).deleteRecursively()
 
     fun deletePublicFolder(context: Context) =
-            File(context.filesDir, PUBLIC_IMAGES_PATH).deleteRecursively()
+        File(context.filesDir, PUBLIC_IMAGES_PATH).deleteRecursively()
+
+    companion object {
+        private const val PUBLIC_IMAGES_PATH = "public_images"
+    }
 }

--- a/app/src/main/java/org/falaeapp/falae/storage/FileHandler.kt
+++ b/app/src/main/java/org/falaeapp/falae/storage/FileHandler.kt
@@ -32,8 +32,9 @@ class FileHandler {
         return File(folder, "$fileName.$extension")
     }
 
-    fun deleteUserFolder(context: Context, folderName: String) {
-        val folder = File(context.filesDir, folderName)
-        folder.deleteRecursively()
-    }
+    fun deleteUserFolder(context: Context, folderName: String) =
+            File(context.filesDir, folderName).deleteRecursively()
+
+    fun deletePublicFolder(context: Context) =
+            File(context.filesDir, PUBLIC_IMAGES_PATH).deleteRecursively()
 }

--- a/app/src/main/java/org/falaeapp/falae/util/Util.kt
+++ b/app/src/main/java/org/falaeapp/falae/util/Util.kt
@@ -1,7 +1,7 @@
 package org.falaeapp.falae.util
 
 import android.content.Context
-import android.support.v7.app.AlertDialog
+import androidx.appcompat.app.AlertDialog
 import org.falaeapp.falae.R
 
 object Util {

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/DisplayViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/DisplayViewModel.kt
@@ -18,7 +18,7 @@ class DisplayViewModel(application: Application) : AndroidViewModel(application)
         liveData(Dispatchers.Default) {
             val page = currentSpreadSheet.pages.find { it.name == linkTo }
             page?.apply {
-                initialPage = isInitialPage(page)
+                initialPage = isInitialPage(this)
                 emit(this)
             }
         }
@@ -33,7 +33,7 @@ class DisplayViewModel(application: Application) : AndroidViewModel(application)
 
     fun init(spreadSheet: SpreadSheet) {
         currentSpreadSheet = spreadSheet
-        spreadSheet.initialPage?.let {
+        currentSpreadSheet.initialPage?.let {
             openPage(it)
         }
     }
@@ -42,7 +42,7 @@ class DisplayViewModel(application: Application) : AndroidViewModel(application)
         linkToPage.value = linkTo
     }
 
-    private fun isInitialPage(page: Page?) = page?.name == currentSpreadSheet.initialPage
+    private fun isInitialPage(page: Page) = page.name == currentSpreadSheet.initialPage
 
     fun setCurrentPage(page: Page) {
         newPage.value = page

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/DisplayViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/DisplayViewModel.kt
@@ -2,14 +2,18 @@ package org.falaeapp.falae.viewmodel
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import org.falaeapp.falae.model.Page
 import org.falaeapp.falae.model.SpreadSheet
 
 class DisplayViewModel(application: Application) : AndroidViewModel(application) {
-    private var currentSpreadSheet: MutableLiveData<SpreadSheet> = MutableLiveData()
-    var pageToOpen: MutableLiveData<Page> = MutableLiveData()
-    var currentPage: MutableLiveData<Page> = MutableLiveData()
+    private val currentSpreadSheet: MutableLiveData<SpreadSheet> = MutableLiveData()
+    private val _pageToOpen: MutableLiveData<Page> = MutableLiveData()
+    val pageToOpen: LiveData<Page> = _pageToOpen
+
+    private val _currentPage: MutableLiveData<Page> = MutableLiveData()
+    val currentPage: LiveData<Page> = _currentPage
 
     fun init(spreadSheet: SpreadSheet?) {
         if (spreadSheet == null) {
@@ -24,12 +28,12 @@ class DisplayViewModel(application: Application) : AndroidViewModel(application)
     fun openPage(linkTo: String) {
         val page = currentSpreadSheet.value?.pages?.find { it.name == linkTo }
         page?.initialPage = isInitialPage(page)
-        pageToOpen.value = page
+        _pageToOpen.value = page
     }
 
     private fun isInitialPage(page: Page?) = page?.name == currentSpreadSheet.value?.initialPage
 
     fun setCurrentPage(page: Page) {
-        currentPage.value = page
+        _currentPage.value = page
     }
 }

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/DisplayViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/DisplayViewModel.kt
@@ -1,8 +1,8 @@
 package org.falaeapp.falae.viewmodel
 
 import android.app.Application
-import android.arch.lifecycle.AndroidViewModel
-import android.arch.lifecycle.MutableLiveData
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.MutableLiveData
 import org.falaeapp.falae.model.Page
 import org.falaeapp.falae.model.SpreadSheet
 

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/SettingsViewModel.kt
@@ -16,48 +16,40 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     private val scanModeEnabledEvent: MutableLiveData<Event<Any>> = MutableLiveData()
     val isScanModeEnabled: LiveData<Boolean> = scanModeEnabledEvent.switchMap { event ->
-        event?.getContentIfAny()?.let { checked ->
-            viewModelScope.launch {
+        liveData {
+            event?.getContentIfAny()?.let { checked ->
                 settingsRepository.saveEnableScanMode(checked as Boolean)
             }
-        }
-        liveData {
             emit(settingsRepository.isScanModeEnabled())
         }
     }
 
     private val feedbackSoundEnabledEvent: MutableLiveData<Event<Any>> = MutableLiveData()
     val isFeedbackSoundEnabled: LiveData<Boolean> = feedbackSoundEnabledEvent.switchMap { event ->
-        event?.getContentIfAny()?.let { checked ->
-            viewModelScope.launch {
+        liveData {
+            event?.getContentIfAny()?.let { checked ->
                 settingsRepository.saveEnableFeedbackSound(checked as Boolean)
             }
-        }
-        liveData {
             emit(settingsRepository.isFeedbackSoundEnabled())
         }
     }
 
     private val automaticNextPageEnabledEvent: MutableLiveData<Event<Any>> = MutableLiveData()
     val isAutomaticNextPageEnabled: LiveData<Boolean> = automaticNextPageEnabledEvent.switchMap { event ->
-        event?.getContentIfAny()?.let { checked ->
-            viewModelScope.launch {
+        liveData {
+            event?.getContentIfAny()?.let { checked ->
                 settingsRepository.saveEnableAutomaticNextPage(checked as Boolean)
             }
-        }
-        liveData {
             emit(settingsRepository.isAutomaticNextPageEnabled())
         }
     }
 
     private val seekBarProgressEvent: MutableLiveData<Event<Any>> = MutableLiveData()
     val seekBarProgress: LiveData<Int> = seekBarProgressEvent.switchMap { event ->
-        event?.getContentIfAny()?.let { progress ->
-            viewModelScope.launch {
+        liveData {
+            event?.getContentIfAny()?.let { progress ->
                 settingsRepository.saveSeekBarProgress(progress as Int)
             }
-        }
-        liveData {
             emit(settingsRepository.getSeekBarProgress())
         }
     }

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/SettingsViewModel.kt
@@ -16,7 +16,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     private val scanModeEnabled: MutableLiveData<Event<Any>> = MutableLiveData()
     val isScanModeEnabled: LiveData<Boolean> = scanModeEnabled.switchMap { event ->
-        event?.getContentIfNotHandled()?.let { checked ->
+        event?.getContentIfNotEmpty()?.let { checked ->
             viewModelScope.launch {
                 settingsRepository.saveEnableScanMode(checked as Boolean)
             }
@@ -28,7 +28,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     private val feedbackSoundEnabled: MutableLiveData<Event<Any>> = MutableLiveData()
     val isFeedbackSoundEnabled: LiveData<Boolean> = feedbackSoundEnabled.switchMap { event ->
-        event?.getContentIfNotHandled()?.let { checked ->
+        event?.getContentIfNotEmpty()?.let { checked ->
             viewModelScope.launch {
                 settingsRepository.saveEnableFeedbackSound(checked as Boolean)
             }
@@ -40,7 +40,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     private val automaticNextPageEnabled: MutableLiveData<Event<Any>> = MutableLiveData()
     val isAutomaticNextPageEnabled: LiveData<Boolean> = automaticNextPageEnabled.switchMap { event ->
-        event?.getContentIfNotHandled()?.let { checked ->
+        event?.getContentIfNotEmpty()?.let { checked ->
             viewModelScope.launch {
                 settingsRepository.saveEnableAutomaticNextPage(checked as Boolean)
             }
@@ -52,7 +52,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     private val progressSeekBar: MutableLiveData<Event<Any>> = MutableLiveData()
     val seekBarProgress: LiveData<Int> = progressSeekBar.switchMap { event ->
-        event?.getContentIfNotHandled()?.let { progress ->
+        event?.getContentIfNotEmpty()?.let { progress ->
             viewModelScope.launch {
                 settingsRepository.saveSeekBarProgress(progress as Int)
             }

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/SettingsViewModel.kt
@@ -1,9 +1,9 @@
 package org.falaeapp.falae.viewmodel
 
 import android.app.Application
-import android.arch.lifecycle.AndroidViewModel
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MutableLiveData
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import org.falaeapp.falae.repository.SettingsRepository
 
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/SettingsViewModel.kt
@@ -8,25 +8,33 @@ import org.falaeapp.falae.repository.SettingsRepository
 
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
     private val settingsRepository: SettingsRepository = SettingsRepository(application)
-    var isScanModeEnabled: MutableLiveData<Boolean> = MutableLiveData()
-    var seekBarProgress: MutableLiveData<Int> = MutableLiveData()
-    var isFeedbackSoundEnabled: MutableLiveData<Boolean> = MutableLiveData()
-    var isAutomaticNextPageEnabled: MutableLiveData<Boolean> = MutableLiveData()
+
+    private val _isScanModeEnabled: MutableLiveData<Boolean> = MutableLiveData()
+    val isScanModeEnabled: LiveData<Boolean> = _isScanModeEnabled
+
+    private val _seekBarProgress: MutableLiveData<Int> = MutableLiveData()
+    val seekBarProgress: LiveData<Int> = _seekBarProgress
+
+    private val _isFeedbackSoundEnabled: MutableLiveData<Boolean> = MutableLiveData()
+    val isFeedbackSoundEnabled: LiveData<Boolean> = _isFeedbackSoundEnabled
+
+    private val _isAutomaticNextPageEnabled: MutableLiveData<Boolean> = MutableLiveData()
+    val isAutomaticNextPageEnabled: LiveData<Boolean> = _isAutomaticNextPageEnabled
 
     fun loadScan() {
-        isScanModeEnabled.value = settingsRepository.isScanModeEnabled()
+        _isScanModeEnabled.value = settingsRepository.isScanModeEnabled()
     }
 
     fun loadFeedbackSound() {
-        isFeedbackSoundEnabled.value = settingsRepository.isFeedbackSoundEnabled()
+        _isFeedbackSoundEnabled.value = settingsRepository.isFeedbackSoundEnabled()
     }
 
     fun loadAutomaticNextPage() {
-        isAutomaticNextPageEnabled.value = settingsRepository.isAutomaticNextPageEnabled()
+        _isAutomaticNextPageEnabled.value = settingsRepository.isAutomaticNextPageEnabled()
     }
 
     fun loadSeekBarProgress() {
-        seekBarProgress.value = settingsRepository.getSeekBarProgress()
+        _seekBarProgress.value = settingsRepository.getSeekBarProgress()
     }
 
     fun setScanModeChecked(checked: Boolean) {

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/SettingsViewModel.kt
@@ -14,9 +14,9 @@ import org.falaeapp.falae.repository.SettingsRepository
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
     private val settingsRepository: SettingsRepository = SettingsRepository(application)
 
-    private val scanModeEnabled: MutableLiveData<Event<Any>> = MutableLiveData()
-    val isScanModeEnabled: LiveData<Boolean> = scanModeEnabled.switchMap { event ->
-        event?.getContentIfNotEmpty()?.let { checked ->
+    private val scanModeEnabledEvent: MutableLiveData<Event<Any>> = MutableLiveData()
+    val isScanModeEnabled: LiveData<Boolean> = scanModeEnabledEvent.switchMap { event ->
+        event?.getContentIfAny()?.let { checked ->
             viewModelScope.launch {
                 settingsRepository.saveEnableScanMode(checked as Boolean)
             }
@@ -26,9 +26,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
-    private val feedbackSoundEnabled: MutableLiveData<Event<Any>> = MutableLiveData()
-    val isFeedbackSoundEnabled: LiveData<Boolean> = feedbackSoundEnabled.switchMap { event ->
-        event?.getContentIfNotEmpty()?.let { checked ->
+    private val feedbackSoundEnabledEvent: MutableLiveData<Event<Any>> = MutableLiveData()
+    val isFeedbackSoundEnabled: LiveData<Boolean> = feedbackSoundEnabledEvent.switchMap { event ->
+        event?.getContentIfAny()?.let { checked ->
             viewModelScope.launch {
                 settingsRepository.saveEnableFeedbackSound(checked as Boolean)
             }
@@ -38,9 +38,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
-    private val automaticNextPageEnabled: MutableLiveData<Event<Any>> = MutableLiveData()
-    val isAutomaticNextPageEnabled: LiveData<Boolean> = automaticNextPageEnabled.switchMap { event ->
-        event?.getContentIfNotEmpty()?.let { checked ->
+    private val automaticNextPageEnabledEvent: MutableLiveData<Event<Any>> = MutableLiveData()
+    val isAutomaticNextPageEnabled: LiveData<Boolean> = automaticNextPageEnabledEvent.switchMap { event ->
+        event?.getContentIfAny()?.let { checked ->
             viewModelScope.launch {
                 settingsRepository.saveEnableAutomaticNextPage(checked as Boolean)
             }
@@ -50,9 +50,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
-    private val progressSeekBar: MutableLiveData<Event<Any>> = MutableLiveData()
-    val seekBarProgress: LiveData<Int> = progressSeekBar.switchMap { event ->
-        event?.getContentIfNotEmpty()?.let { progress ->
+    private val seekBarProgressEvent: MutableLiveData<Event<Any>> = MutableLiveData()
+    val seekBarProgress: LiveData<Int> = seekBarProgressEvent.switchMap { event ->
+        event?.getContentIfAny()?.let { progress ->
             viewModelScope.launch {
                 settingsRepository.saveSeekBarProgress(progress as Int)
             }
@@ -63,35 +63,35 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     }
 
     fun loadScan() {
-        scanModeEnabled.value = Event(Unit)
+        scanModeEnabledEvent.value = Event(Unit)
     }
 
     fun loadFeedbackSound() {
-        feedbackSoundEnabled.value = Event(Unit)
+        feedbackSoundEnabledEvent.value = Event(Unit)
     }
 
     fun loadAutomaticNextPage() {
-        automaticNextPageEnabled.value = Event(Unit)
+        automaticNextPageEnabledEvent.value = Event(Unit)
     }
 
     fun loadSeekBarProgress() {
-        progressSeekBar.value = Event(Unit)
+        seekBarProgressEvent.value = Event(Unit)
     }
 
     fun setScanModeChecked(checked: Boolean) {
-        scanModeEnabled.value = Event(checked)
+        scanModeEnabledEvent.value = Event(checked)
     }
 
     fun setFeedbackSoundChecked(checked: Boolean) {
-        feedbackSoundEnabled.value = Event(checked)
+        feedbackSoundEnabledEvent.value = Event(checked)
     }
 
     fun setAutomaticNextPageChecked(checked: Boolean) {
-        automaticNextPageEnabled.value = Event(checked)
+        automaticNextPageEnabledEvent.value = Event(checked)
     }
 
     fun setSeekBarProgress(progress: Int) {
-        progressSeekBar.value = Event(progress)
+        seekBarProgressEvent.value = Event(progress)
     }
 
     fun setScanModeDuration(timeMillis: Long) {

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/UserViewModel.kt
@@ -4,19 +4,27 @@ import android.app.Application
 import android.arch.lifecycle.AndroidViewModel
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import org.falaeapp.falae.Event
 import org.falaeapp.falae.model.User
 import org.falaeapp.falae.repository.UserRepository
 import org.jetbrains.anko.doAsync
 
+class UserViewModel(application: Application) : AndroidViewModel(application), CoroutineScope {
 
-class UserViewModel(application: Application) : AndroidViewModel(application) {
+    private val viewModelJob = SupervisorJob()
+
+    override val coroutineContext = Dispatchers.Main + viewModelJob
 
     private val userRepository: UserRepository = UserRepository(application)
     val users: LiveData<List<User>>
     var currentUser: LiveData<User> = MutableLiveData()
     val reposResult = MutableLiveData<Event<Pair<User?, Exception?>>>()
     val lastConnectedUserId: MutableLiveData<Long> = MutableLiveData()
+    val clearCache = MutableLiveData<Event<Boolean>>()
 
     init {
         users = userRepository.getAllUsers()
@@ -50,5 +58,24 @@ class UserViewModel(application: Application) : AndroidViewModel(application) {
 
     fun handleNewVersion(versionCode: Int) {
         userRepository.handleNewVersion(versionCode)
+    }
+
+    fun clearUserCache() {
+        currentUser.value?.let { user ->
+            launch {
+                clearCache.value = Event(userRepository.clearUserCache(user.email))
+            }
+        }
+    }
+
+    fun clearPublicCache() {
+        launch {
+            clearCache.value = Event(userRepository.clearPublicCache())
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        viewModelJob.cancel()
     }
 }

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/UserViewModel.kt
@@ -56,10 +56,8 @@ class UserViewModel(application: Application) : AndroidViewModel(application) {
     fun loadUser(userId: Long) {
         currentUser = liveData {
             val user = userRepository.getUser(userId)
-            emit(user)
-        }
-        viewModelScope.launch {
             userRepository.saveLastConnectedUserId(userId)
+            emit(user)
         }
     }
 

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/UserViewModel.kt
@@ -16,7 +16,6 @@ class UserViewModel(application: Application) : AndroidViewModel(application) {
     private val userRepository: UserRepository = UserRepository(application)
     var users: LiveData<List<User>> = liveData {
         emitSource(userRepository.getAllUsers())
-        loadLastConnectedUser()
     }
     var currentUser: LiveData<User> = MutableLiveData()
     val reposResult = MutableLiveData<Event<Pair<User?, Exception?>>>()

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/UserViewModel.kt
@@ -46,13 +46,10 @@ class UserViewModel(application: Application) : AndroidViewModel(application), C
     fun synchronizeUser(email: String, password: String) {
         launch {
             try {
-                var user = userRepository.login(email, password)
-                user = userRepository.downloadImages(user)
-                val userId = userRepository.saveOrUpdateUser(user)
-                userRepository.saveLastConnectedUserId(userId)
-                lastConnectedUserId.postValue(userId)
-                getAllUsers()
+                val user = userRepository.synchAccount(email, password)
+                lastConnectedUserId.postValue(user.id.toLong())
                 reposResult.postValue(Event(Pair(user, null)))
+                getAllUsers()
             } catch (exception: Exception) {
                 reposResult.postValue(Event(Pair(null, exception)))
             }

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/UserViewModel.kt
@@ -30,7 +30,7 @@ class UserViewModel(application: Application) : AndroidViewModel(application) {
     private val lastConnectedUserIdEvent: MutableLiveData<Event<Any>> = MutableLiveData()
     val lastConnectedUserId: LiveData<Long> = lastConnectedUserIdEvent.switchMap { event ->
         liveData {
-            event?.getContentIfNotEmpty()?.let { userId ->
+            event?.getContentIfAny()?.let { userId ->
                 emit(userId as Long)
             } ?: run {
                 emit(userRepository.getLastConnectedUserId())
@@ -41,7 +41,7 @@ class UserViewModel(application: Application) : AndroidViewModel(application) {
     private val clearCacheEvent = MutableLiveData<Event<Any>>()
     val clearCache: LiveData<Event<Boolean>> = clearCacheEvent.switchMap { event ->
         liveData {
-            event?.getContentIfNotEmpty()?.let { email ->
+            event?.getContentIfAny()?.let { email ->
                 emit(Event(userRepository.clearUserCache(email as String)))
             } ?: run {
                 emit(Event(userRepository.clearPublicCache()))

--- a/app/src/main/java/org/falaeapp/falae/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/org/falaeapp/falae/viewmodel/UserViewModel.kt
@@ -1,21 +1,15 @@
 package org.falaeapp.falae.viewmodel
 
 import android.app.Application
-import android.arch.lifecycle.AndroidViewModel
-import android.arch.lifecycle.MutableLiveData
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import org.falaeapp.falae.Event
 import org.falaeapp.falae.model.User
 import org.falaeapp.falae.repository.UserRepository
 
-class UserViewModel(application: Application) : AndroidViewModel(application), CoroutineScope {
-
-    private val viewModelJob = SupervisorJob()
-
-    override val coroutineContext = Dispatchers.Main + viewModelJob
+class UserViewModel(application: Application) : AndroidViewModel(application) {
 
     private val userRepository: UserRepository = UserRepository(application)
     var users = MutableLiveData<List<User>>()
@@ -25,26 +19,26 @@ class UserViewModel(application: Application) : AndroidViewModel(application), C
     val clearCache = MutableLiveData<Event<Boolean>>()
 
     init {
-        launch {
+        viewModelScope.launch {
             getAllUsers()
         }
     }
 
     fun loadLastConnectedUser() {
-        launch {
+        viewModelScope.launch {
             lastConnectedUserId.postValue(userRepository.getLastConnectedUserId())
         }
     }
 
     fun loadUser(userId: Long) {
-        launch {
+        viewModelScope.launch {
             userRepository.saveLastConnectedUserId(userId)
             currentUser.value = userRepository.getUser(userId)
         }
     }
 
     fun synchronizeUser(email: String, password: String) {
-        launch {
+        viewModelScope.launch {
             try {
                 val user = userRepository.synchAccount(email, password)
                 lastConnectedUserId.postValue(user.id.toLong())
@@ -58,7 +52,7 @@ class UserViewModel(application: Application) : AndroidViewModel(application), C
 
     fun removeUser() {
         currentUser.value?.let { user ->
-            launch {
+            viewModelScope.launch {
                 userRepository.remove(user)
                 getAllUsers()
             }
@@ -70,27 +64,22 @@ class UserViewModel(application: Application) : AndroidViewModel(application), C
     }
 
     fun handleNewVersion(versionCode: Int) {
-        launch {
+        viewModelScope.launch {
             userRepository.handleNewVersion(versionCode)
         }
     }
 
     fun clearUserCache() {
         currentUser.value?.let { user ->
-            launch {
+            viewModelScope.launch {
                 clearCache.value = Event(userRepository.clearUserCache(user.email))
             }
         }
     }
 
     fun clearPublicCache() {
-        launch {
+        viewModelScope.launch {
             clearCache.value = Event(userRepository.clearPublicCache())
         }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        viewModelJob.cancel()
     }
 }

--- a/app/src/main/res/layout/activity_display.xml
+++ b/app/src/main/res/layout/activity_display.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="org.falaeapp.falae.activity.DisplayActivity">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                                   xmlns:tools="http://schemas.android.com/tools"
+                                                   android:layout_width="match_parent"
+                                                   android:layout_height="match_parent"
+                                                   tools:context="org.falaeapp.falae.activity.DisplayActivity">
 
     <FrameLayout
         android:id="@+id/page_container"
@@ -12,4 +12,4 @@
         tools:layout_editor_absoluteY="8dp"
         tools:layout_editor_absoluteX="8dp" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/drawer_layout"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    tools:openDrawer="start">
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                           xmlns:app="http://schemas.android.com/apk/res-auto"
+                                           xmlns:tools="http://schemas.android.com/tools"
+                                           android:id="@+id/drawer_layout"
+                                           android:layout_width="match_parent"
+                                           android:layout_height="match_parent"
+                                           android:fitsSystemWindows="true"
+                                           tools:openDrawer="start">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -26,7 +26,7 @@
             android:layout_height="match_parent" />
     </LinearLayout>
 
-    <android.support.design.widget.NavigationView
+    <com.google.android.material.navigation.NavigationView
         android:id="@+id/nav_view"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
@@ -37,4 +37,4 @@
         app:itemTextColor="@color/black"
         app:itemIconTint="@color/black"/>
 
-</android.support.v4.widget.DrawerLayout>
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/app_bar_navigation.xml
+++ b/app/src/main/res/layout/app_bar_navigation.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior"
-    tools:context="org.falaeapp.falae.activity.MainActivity">
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                                     xmlns:app="http://schemas.android.com/apk/res-auto"
+                                                     xmlns:tools="http://schemas.android.com/tools"
+                                                     android:layout_width="match_parent"
+                                                     android:layout_height="match_parent"
+                                                     app:layout_behavior="@string/appbar_scrolling_view_behavior"
+                                                     tools:context="org.falaeapp.falae.activity.MainActivity">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">
 
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_page.xml
+++ b/app/src/main/res/layout/fragment_page.xml
@@ -19,7 +19,7 @@
             android:visibility="invisible" />
     </FrameLayout>
 
-    <android.support.v4.view.ViewPager
+    <androidx.viewpager.widget.ViewPager
         android:id="@+id/pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -95,7 +95,50 @@
                 android:text="@string/scan_mode"
                 android:textColor="@color/colorPrimary"
                 android:textSize="@dimen/default_text_size" />
+        </RelativeLayout>
 
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_margin="@dimen/default_horizontal_margin">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/small_vertical_margin"
+                android:background="@drawable/border"
+                android:orientation="horizontal"
+                android:padding="15dp">
+
+                <Button
+                    android:id="@+id/bt_clear_user_cache"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginEnd="@dimen/tiny_horizontal_margin"
+                    android:layout_marginRight="@dimen/tiny_horizontal_margin"
+                    android:layout_weight="1"
+                    android:text="@string/clear_user_cache" />
+
+                <Button
+                    android:id="@+id/bt_clear_public_cache"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_weight="1"
+                    android:text="@string/clear_public_cache" />
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_marginStart="@dimen/default_horizontal_margin"
+                android:layout_marginLeft="@dimen/default_horizontal_margin"
+                android:background="@color/white"
+                android:text="@string/cache"
+                android:textColor="@color/colorPrimary"
+                android:textSize="@dimen/default_text_size" />
         </RelativeLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -1,144 +1,145 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
         <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_margin="@dimen/default_horizontal_margin">
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_margin="@dimen/default_horizontal_margin">
 
             <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/small_vertical_margin"
-                android:background="@drawable/border"
-                android:orientation="vertical"
-                android:padding="15dp">
-
-                <Switch
-                    android:id="@+id/scan_mode"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/default_horizontal_margin"
-                    android:layout_marginTop="@dimen/default_vertical_margin"
-                    android:layout_marginRight="@dimen/default_horizontal_margin"
-                    android:layout_marginBottom="@dimen/default_vertical_margin"
-                    android:gravity="start"
-                    android:switchPadding="@dimen/small_horizontal_margin"
-                    android:text="@string/scan_mode"
-                    android:textColor="@color/darkGreen" />
+                    android:layout_marginTop="@dimen/small_vertical_margin"
+                    android:background="@drawable/border"
+                    android:orientation="vertical"
+                    android:padding="15dp">
 
                 <Switch
-                    android:id="@+id/feedback_sound"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/default_horizontal_margin"
-                    android:layout_marginRight="@dimen/default_horizontal_margin"
-                    android:layout_marginBottom="@dimen/default_vertical_margin"
-                    android:gravity="start"
-                    android:switchPadding="@dimen/small_horizontal_margin"
-                    android:text="@string/feedback_sound"
-                    android:textColor="@color/darkGreen" />
+                        android:id="@+id/scan_mode"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="@dimen/default_horizontal_margin"
+                        android:layout_marginTop="@dimen/default_vertical_margin"
+                        android:layout_marginRight="@dimen/default_horizontal_margin"
+                        android:layout_marginBottom="@dimen/default_vertical_margin"
+                        android:gravity="start"
+                        android:switchPadding="@dimen/small_horizontal_margin"
+                        android:text="@string/scan_mode"
+                        android:textColor="@color/darkGreen"/>
 
                 <Switch
-                    android:id="@+id/automatic_next_page"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/default_horizontal_margin"
-                    android:layout_marginRight="@dimen/default_horizontal_margin"
-                    android:layout_marginBottom="@dimen/default_vertical_margin"
-                    android:gravity="start"
-                    android:switchPadding="@dimen/small_horizontal_margin"
-                    android:text="@string/scan_mode_automatic_next_page"
-                    android:textColor="@color/darkGreen" />
+                        android:id="@+id/feedback_sound"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="@dimen/default_horizontal_margin"
+                        android:layout_marginRight="@dimen/default_horizontal_margin"
+                        android:layout_marginBottom="@dimen/default_vertical_margin"
+                        android:gravity="start"
+                        android:switchPadding="@dimen/small_horizontal_margin"
+                        android:text="@string/feedback_sound"
+                        android:textColor="@color/darkGreen"/>
+
+                <Switch
+                        android:id="@+id/automatic_next_page"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="@dimen/default_horizontal_margin"
+                        android:layout_marginRight="@dimen/default_horizontal_margin"
+                        android:layout_marginBottom="@dimen/default_vertical_margin"
+                        android:gravity="start"
+                        android:switchPadding="@dimen/small_horizontal_margin"
+                        android:text="@string/scan_mode_automatic_next_page"
+                        android:textColor="@color/darkGreen"/>
 
                 <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/default_horizontal_margin"
-                    android:layout_marginLeft="@dimen/default_horizontal_margin"
-                    android:layout_marginBottom="@dimen/default_horizontal_margin"
-                    android:gravity="start"
-                    android:text="@string/scan_mode_duration" />
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/default_horizontal_margin"
+                        android:layout_marginLeft="@dimen/default_horizontal_margin"
+                        android:layout_marginBottom="@dimen/default_horizontal_margin"
+                        android:gravity="start"
+                        android:text="@string/scan_mode_duration"/>
 
                 <TextView
-                    android:id="@+id/seekbar_value"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center" />
+                        android:id="@+id/seekbar_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"/>
 
                 <SeekBar
-                    android:id="@+id/seekBar"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:layout_marginStart="@dimen/default_horizontal_margin"
-                    android:layout_marginLeft="@dimen/default_horizontal_margin"
-                    android:layout_marginEnd="@dimen/big_horizontal_margin"
-                    android:layout_marginRight="@dimen/big_horizontal_margin"
-                    android:max="19"
-                    android:progress="0" />
+                        android:id="@+id/seekBar"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:layout_marginStart="@dimen/default_horizontal_margin"
+                        android:layout_marginLeft="@dimen/default_horizontal_margin"
+                        android:layout_marginEnd="@dimen/big_horizontal_margin"
+                        android:layout_marginRight="@dimen/big_horizontal_margin"
+                        android:max="19"
+                        android:progress="0"/>
             </LinearLayout>
 
             <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentTop="true"
-                android:layout_marginStart="@dimen/default_horizontal_margin"
-                android:layout_marginLeft="@dimen/default_horizontal_margin"
-                android:background="@color/white"
-                android:text="@string/scan_mode"
-                android:textColor="@color/colorPrimary"
-                android:textSize="@dimen/default_text_size" />
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    android:layout_marginStart="@dimen/default_horizontal_margin"
+                    android:layout_marginLeft="@dimen/default_horizontal_margin"
+                    android:background="@color/white"
+                    android:text="@string/scan_mode"
+                    android:textColor="@color/colorPrimary"
+                    android:textSize="@dimen/default_text_size"/>
         </RelativeLayout>
 
         <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_margin="@dimen/default_horizontal_margin">
+                android:id="@+id/cache_layout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_margin="@dimen/default_horizontal_margin">
 
             <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/small_vertical_margin"
-                android:background="@drawable/border"
-                android:orientation="horizontal"
-                android:padding="15dp">
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/small_vertical_margin"
+                    android:background="@drawable/border"
+                    android:orientation="horizontal"
+                    android:padding="15dp">
 
                 <Button
-                    android:id="@+id/bt_clear_user_cache"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:layout_marginEnd="@dimen/tiny_horizontal_margin"
-                    android:layout_marginRight="@dimen/tiny_horizontal_margin"
-                    android:layout_weight="1"
-                    android:text="@string/clear_user_cache" />
+                        android:id="@+id/bt_clear_user_cache"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:layout_marginEnd="@dimen/tiny_horizontal_margin"
+                        android:layout_marginRight="@dimen/tiny_horizontal_margin"
+                        android:layout_weight="1"
+                        android:text="@string/clear_user_cache"/>
 
                 <Button
-                    android:id="@+id/bt_clear_public_cache"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:text="@string/clear_public_cache" />
+                        android:id="@+id/bt_clear_public_cache"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:layout_weight="1"
+                        android:text="@string/clear_public_cache"/>
             </LinearLayout>
 
             <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentTop="true"
-                android:layout_marginStart="@dimen/default_horizontal_margin"
-                android:layout_marginLeft="@dimen/default_horizontal_margin"
-                android:background="@color/white"
-                android:text="@string/cache"
-                android:textColor="@color/colorPrimary"
-                android:textSize="@dimen/default_text_size" />
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    android:layout_marginStart="@dimen/default_horizontal_margin"
+                    android:layout_marginLeft="@dimen/default_horizontal_margin"
+                    android:background="@color/white"
+                    android:text="@string/cache"
+                    android:textColor="@color/colorPrimary"
+                    android:textSize="@dimen/default_text_size"/>
         </RelativeLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_spread_sheet.xml
+++ b/app/src/main/res/layout/fragment_spread_sheet.xml
@@ -4,7 +4,7 @@
     android:layout_height="match_parent"
     tools:context="org.falaeapp.falae.fragment.SpreadSheetFragment">
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/spreadsheet_recycler"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_sync_user.xml
+++ b/app/src/main/res/layout/fragment_sync_user.xml
@@ -19,7 +19,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <android.support.design.widget.TextInputLayout
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
@@ -33,9 +33,9 @@
                     android:inputType="textEmailAddress"
                     android:maxLines="1" />
 
-            </android.support.design.widget.TextInputLayout>
+            </com.google.android.material.textfield.TextInputLayout>
 
-            <android.support.design.widget.TextInputLayout
+            <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
@@ -50,7 +50,7 @@
                     android:inputType="textPassword"
                     android:maxLines="1" />
 
-            </android.support.design.widget.TextInputLayout>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <Button
                 android:id="@+id/email_sign_in_button"

--- a/app/src/main/res/layout/fragment_tab_pager.xml
+++ b/app/src/main/res/layout/fragment_tab_pager.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.design.widget.TabLayout
+    <com.google.android.material.tabs.TabLayout
         android:id="@+id/layout_tabs"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -16,7 +16,7 @@
         app:tabTextAppearance="@style/TabTextStyle"
         app:tabTextColor="@color/green" />
 
-    <android.support.v4.view.ViewPager
+    <androidx.viewpager.widget.ViewPager
         android:id="@+id/viewpager"
         android:layout_width="match_parent"
         android:layout_height="0px"

--- a/app/src/main/res/layout/fragment_view_pager_item.xml
+++ b/app/src/main/res/layout/fragment_view_pager_item.xml
@@ -2,7 +2,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.GridLayout
+    <androidx.gridlayout.widget.GridLayout
         android:id="@+id/grid_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/item.xml
+++ b/app/src/main/res/layout/item.xml
@@ -4,11 +4,11 @@
     android:layout_height="match_parent"
     android:foreground="@drawable/highlight_fg_selector">
 
-    <android.support.constraint.ConstraintLayout xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:id="@+id/item_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical|center_horizontal">
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+                                                       android:id="@+id/item_layout"
+                                                       android:layout_width="match_parent"
+                                                       android:layout_height="wrap_content"
+                                                       android:layout_gravity="center_vertical|center_horizontal">
 
         <TextView
             android:id="@+id/item_name"
@@ -57,5 +57,5 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_bias="0.0"
             app:srcCompat="@drawable/ic_launch_white_48dp" />
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -47,7 +47,7 @@
     <string name="images_removed">Images successfully removed!</string>
     <string name="images_removed_error">An error occurred while trying to remove the images.</string>
     <string name="confirm_clear_public_cache">This will remove all public images on this device. Are you sure you want to do this?</string>
-    <string name="confirm_clear_user_cache">This will remove all images from "My Items" on this device. Are you sure you want to do this?</string>
+    <string name="confirm_clear_user_cache">This will remove all images from "My Items" on this device. You will have to synchronize your account again. Are you sure you want to do this?</string>
     <string name="clear_user_cache">Clear user cache</string>
     <string name="clear_public_cache">Clear public cache</string>
     <string name="cache">Cache</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -44,10 +44,10 @@
     <string name="picasso_load_error">Could not load image. Please try to re-synchronize your account.</string>
     <string name="background_run">Falaê is running in background.</string>
     <string name="scan_mode_automatic_next_page">Automatic scrolling</string>
-    <string name="images_removed">Images successfully removed!</string>
+    <string name="images_removed">Images removed successfully!</string>
     <string name="images_removed_error">An error occurred while trying to remove the images.</string>
-    <string name="confirm_clear_public_cache">This will remove all public images on this device. Are you sure you want to do this?</string>
-    <string name="confirm_clear_user_cache">This will remove all images from "My Items" on this device. You will have to synchronize your account again. Are you sure you want to do this?</string>
+    <string name="confirm_clear_public_cache">This will remove all public images from this device including ones shared between different user accounts. Are you sure you want to do this?</string>
+    <string name="confirm_clear_user_cache">This will remove all of your private images, listed under "My Items" menu option, from this device. You will need to synchronize your account again. Are you sure you want to do this?</string>
     <string name="clear_user_cache">Clear user cache</string>
     <string name="clear_public_cache">Clear public cache</string>
     <string name="cache">Cache</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -44,9 +44,10 @@
     <string name="picasso_load_error">Could not load image. Please try to re-synchronize your account.</string>
     <string name="background_run">Falaê is running in background.</string>
     <string name="scan_mode_automatic_next_page">Automatic scrolling</string>
-    <string name="public_images_removed">Public images successfully removed!</string>
-    <string name="public_images_removed_error">An error occurred whie trying to remove public images.</string>
-    <string name="confirm_clear_cache">This will remove all synchronized public images. Are you sure you want to do this?</string>
+    <string name="images_removed">Images successfully removed!</string>
+    <string name="images_removed_error">An error occurred while trying to remove the images.</string>
+    <string name="confirm_clear_public_cache">This will remove all public images on this device. Are you sure you want to do this?</string>
+    <string name="confirm_clear_user_cache">This will remove all images from "My Items" on this device. Are you sure you want to do this?</string>
     <string name="clear_user_cache">Clear user cache</string>
     <string name="clear_public_cache">Clear public cache</string>
     <string name="cache">Cache</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -44,4 +44,10 @@
     <string name="picasso_load_error">Could not load image. Please try to re-synchronize your account.</string>
     <string name="background_run">Falaê is running in background.</string>
     <string name="scan_mode_automatic_next_page">Automatic scrolling</string>
+    <string name="public_images_removed">Public images successfully removed!</string>
+    <string name="public_images_removed_error">An error occurred whie trying to remove public images.</string>
+    <string name="confirm_clear_cache">This will remove all synchronized public images. Are you sure you want to do this?</string>
+    <string name="clear_user_cache">Clear user cache</string>
+    <string name="clear_public_cache">Clear public cache</string>
+    <string name="cache">Cache</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -50,4 +50,5 @@
     <string name="clear_user_cache">Clear user cache</string>
     <string name="clear_public_cache">Clear public cache</string>
     <string name="cache">Cache</string>
+    <string name="clear_cache">Clear Cache</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,9 +43,10 @@
     <string name="picasso_load_error">Não foi possível carregar a imagem. Por favor tente re-sincronizar sua conta.</string>
     <string name="background_run">Falaê está rodando em plano de fundo.</string>
     <string name="scan_mode_automatic_next_page">Mudança de página automática</string>
-    <string name="public_images_removed">Imagens publicas removidas com sucesso!</string>
-    <string name="public_images_removed_error">Ocorreu um erro ao tentar remover as imagens publicas</string>
-    <string name="confirm_clear_cache">Isso fará com que todas as imagens publicas sincronizadas sejam removidas. Tem certeza que deseja fazer isso?</string>
+    <string name="images_removed">Imagens removidas com sucesso!</string>
+    <string name="images_removed_error">Ocorreu um erro ao tentar remover as imagens</string>
+    <string name="confirm_clear_public_cache">Isso fará com que todas as imagens públicas sejam removidas neste dispositivo. Tem certeza que deseja fazer isso?</string>
+    <string name="confirm_clear_user_cache">Isso fará com que todas as imagens do menu "meus itens" sejam removidas neste dispositivo. Tem certeza que deseja fazer isso?</string>
     <string name="clear_user_cache">Limpar cache do usuário</string>
     <string name="clear_public_cache">Limpar cache público</string>
     <string name="cache">Cache</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,4 +49,5 @@
     <string name="clear_user_cache">Limpar cache do usuário</string>
     <string name="clear_public_cache">Limpar cache público</string>
     <string name="cache">Cache</string>
+    <string name="clear_cache">Limpar Cache</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,10 @@
     <string name="picasso_load_error">Não foi possível carregar a imagem. Por favor tente re-sincronizar sua conta.</string>
     <string name="background_run">Falaê está rodando em plano de fundo.</string>
     <string name="scan_mode_automatic_next_page">Mudança de página automática</string>
+    <string name="public_images_removed">Imagens publicas removidas com sucesso!</string>
+    <string name="public_images_removed_error">Ocorreu um erro ao tentar remover as imagens publicas</string>
+    <string name="confirm_clear_cache">Isso fará com que todas as imagens publicas sincronizadas sejam removidas. Tem certeza que deseja fazer isso?</string>
+    <string name="clear_user_cache">Limpar cache do usuário</string>
+    <string name="clear_public_cache">Limpar cache público</string>
+    <string name="cache">Cache</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
     <string name="images_removed">Imagens removidas com sucesso!</string>
     <string name="images_removed_error">Ocorreu um erro ao tentar remover as imagens</string>
     <string name="confirm_clear_public_cache">Isso fará com que todas as imagens públicas sejam removidas neste dispositivo. Tem certeza que deseja fazer isso?</string>
-    <string name="confirm_clear_user_cache">Isso fará com que todas as imagens do menu "meus itens" sejam removidas neste dispositivo. Tem certeza que deseja fazer isso?</string>
+    <string name="confirm_clear_user_cache">Isso fará com que todas as imagens do menu "meus itens" sejam removidas neste dispositivo. Você precisará sincronizar sua conta novamente. Tem certeza que deseja fazer isso?</string>
     <string name="clear_user_cache">Limpar cache do usuário</string>
     <string name="clear_public_cache">Limpar cache público</string>
     <string name="cache">Cache</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,9 +44,9 @@
     <string name="background_run">Falaê está rodando em plano de fundo.</string>
     <string name="scan_mode_automatic_next_page">Mudança de página automática</string>
     <string name="images_removed">Imagens removidas com sucesso!</string>
-    <string name="images_removed_error">Ocorreu um erro ao tentar remover as imagens</string>
-    <string name="confirm_clear_public_cache">Isso fará com que todas as imagens públicas sejam removidas neste dispositivo. Tem certeza que deseja fazer isso?</string>
-    <string name="confirm_clear_user_cache">Isso fará com que todas as imagens do menu "meus itens" sejam removidas neste dispositivo. Você precisará sincronizar sua conta novamente. Tem certeza que deseja fazer isso?</string>
+    <string name="images_removed_error">Ocorreu um erro ao tentar remover as imagens.</string>
+    <string name="confirm_clear_public_cache">Isso fará com que todas imagens públicas, compartilhadas entre diferentes usuários, sejam removidas deste dispositivo. Tem certeza que deseja fazer isso?</string>
+    <string name="confirm_clear_user_cache">Isso fará com que todas suas imagens privadas do menu "Meus Itens" sejam removidas deste dispositivo. Você precisará sincronizar sua conta novamente. Tem certeza que deseja fazer isso?</string>
     <string name="clear_user_cache">Limpar cache do usuário</string>
     <string name="clear_public_cache">Limpar cache público</string>
     <string name="cache">Cache</string>

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.3.50'
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -21,16 +21,6 @@ allprojects {
         jcenter()
         google()
     }
-}
-
-ext {
-    supportLibVersion = "28.0.0"
-    runnerVersion = "1.0.1"
-    rulesVersion = "1.0.1"
-    espressoVersion = "3.0.1"
-    archLifecycleVersion = '2.0.0-beta01'
-    archRoomVersion = '2.0.0-beta01'
-    anko_version = '0.10.5'
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ ext {
     runnerVersion = "1.0.1"
     rulesVersion = "1.0.1"
     espressoVersion = "3.0.1"
-    archLifecycleVersion = "1.1.1"
-    archRoomVersion = "1.1.1"
+    archLifecycleVersion = '2.0.0-beta01'
+    archRoomVersion = '2.0.0-beta01'
     anko_version = '0.10.5'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue May 30 18:32:54 BRT 2017
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 systemProp.http.proxyPort=8088


### PR DESCRIPTION
Lots of changes in this PR:
- Migration to AndroidX
- Added Kotlin Coroutines and removed callbacks
  - Removed Anko deps
  - Refactor in all ViewModel files
  - Addressed some common mistakes when using Architecture Components.
- AndroidX has deprecated userVisibleHint and fixed the fragment visibility in ViewPager, so FragmentLifeCycle is no longer needed since Android can now handle it internally.
- Disable extra scan options when scan mode is disabled.
- Lots of code changes to make it better readable
- Added Clear public/private cache so the user can re-download the images again.
